### PR TITLE
feat: node shell, cordon and PDB-aware drain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,10 @@ klustr/
 │       ├── overview.go              cluster-wide CPU / memory / pod aggregation
 │       ├── logs.go                  streaming log sessions
 │       ├── exec.go                  SPDY exec sessions
+│       ├── nodeshell.go             root node shell via a temporary privileged
+│       │                            nsenter pod, attached through exec.go
+│       ├── nodeops.go               node cordon/uncordon + PDB-aware drain
+│       │                            (eviction API, streamed progress)
 │       └── portforward.go           port-forward registry & lifecycle
 ├── app/                          Wails binding adapter (thin layer over ClientManager)
 ├── frontend/

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Klustr is a cross-platform Kubernetes desktop client built with [Wails](https://
 - 🔐 **cert-manager.** Certificates, Issuers / ClusterIssuers, and the full issuance chain — CertificateRequest → Order → Challenge — with ready/expiry status and a drill-down across the chain. One-click **Renew**, no `cmctl` CLI.
 - 📜 **Logs.** Stern-style multi-pod streaming with per-pod ANSI colors, follow, save and regex.
 - 🖥️ **In-app exec.** SPDY shell into any container.
+- 🐚 **Node shell.** Root shell on any node via a temporary privileged `nsenter` pod that's removed when the session ends — no SSH, nothing pre-installed.
+- 🚧 **Cordon & drain.** One-click cordon/uncordon and a live-progress drain that evicts through the Eviction API (PDB-aware, skips DaemonSet & mirror pods).
 - 🔧 **YAML edit.** Monaco editor with a server-side dry-run diff before apply.
 - 🚀 **Scale, restart, pause/resume.** Replica controls, one-click rolling restart, inline pause/resume, HPA min/max editable inline.
 - ⏪ **Rollout history & rollback.** Side-by-side template diff and one-click revert on Deployments / StatefulSets / DaemonSets.
@@ -190,6 +192,7 @@ Full design notes, conventions and the "add a new resource kind" recipe live in 
 - [x] Every built-in resource kind (incl. full RBAC: ServiceAccounts, Roles, RoleBindings, ClusterRoles, ClusterRoleBindings)
 - [x] **Access Review** — subject → effective-permission matrix with binding trace, implicit-group expansion (`system:serviceaccounts:*`, `system:authenticated`), wildcard / cluster-admin detection, live across every active context
 - [x] Logs, exec, port-forwarding
+- [x] Node shell (privileged `nsenter` pod), cordon/uncordon, PDB-aware drain
 - [x] YAML edit / apply with diff, scale, restart, deployment pause/resume, HPA inline edit
 - [x] Rollout history with revision diff and one-click rollback (Deployments / StatefulSets / DaemonSets)
 - [x] Cross-resource navigation (related pods, owner/node links, back stack)

--- a/app/app.go
+++ b/app/app.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"runtime/debug"
+	"time"
 
 	"klustr/internal/kube"
 	"klustr/internal/update"
@@ -395,6 +396,59 @@ func (a *App) ResizeExec(sessionID string, cols, rows int) {
 
 func (a *App) StopExec(sessionID string) {
 	a.clients.StopExec(sessionID)
+}
+
+func (a *App) StartNodeShell(contextName, nodeName string) (string, error) {
+	var sessionID string
+	id, err := a.clients.StartNodeShell(
+		a.ctx, contextName, nodeName,
+		func(data []byte) {
+			if sessionID == "" {
+				return
+			}
+			runtime.EventsEmit(a.ctx, "exec:out:"+sessionID, string(data))
+		},
+		func(err error) {
+			if sessionID == "" {
+				return
+			}
+			msg := ""
+			if err != nil {
+				msg = err.Error()
+			}
+			runtime.EventsEmit(a.ctx, "exec:close:"+sessionID, msg)
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	sessionID = id
+	return id, nil
+}
+
+func (a *App) CordonNode(contextName, nodeName string, cordon bool) error {
+	return a.clients.SetNodeCordon(a.ctx, contextName, nodeName, cordon)
+}
+
+// DrainNode returns immediately; progress streams over the
+// "node:drain:<context>/<node>" event until a terminal done/error payload.
+func (a *App) DrainNode(contextName, nodeName string) {
+	event := "node:drain:" + contextName + "/" + nodeName
+	go func() {
+		ctx, cancel := context.WithTimeout(a.ctx, 15*time.Minute)
+		defer cancel()
+		err := a.clients.DrainNode(ctx, contextName, nodeName, func(p kube.NodeDrainProgress) {
+			runtime.EventsEmit(a.ctx, event, p)
+		})
+		if err != nil {
+			runtime.EventsEmit(a.ctx, event, kube.NodeDrainProgress{
+				Node:    nodeName,
+				Phase:   "error",
+				Pending: []string{},
+				Error:   err.Error(),
+			})
+		}
+	}()
 }
 
 func (a *App) OpenLocalTerminal(contextName string, cols, rows int) (string, error) {

--- a/frontend/src/features/_shared/ResourceDetailPanel.tsx
+++ b/frontend/src/features/_shared/ResourceDetailPanel.tsx
@@ -78,6 +78,9 @@ import { GRPCRouteDetailBody } from '@/features/grpcroutes/GRPCRouteDetailBody'
 import { GatewayClassDetailBody } from '@/features/gatewayclasses/GatewayClassDetailBody'
 import { ReferenceGrantDetailBody } from '@/features/referencegrants/ReferenceGrantDetailBody'
 import { NodeDetailBody } from '@/features/nodes/NodeDetailBody'
+import { NodeShellTab } from '@/features/nodes/NodeShellTab'
+import { CordonNodeButton } from '@/features/nodes/CordonNodeButton'
+import { DrainNodeButton } from '@/features/nodes/DrainNodeButton'
 import { KarpenterNodesTab } from '@/features/karpenter-nodepools/KarpenterNodesTab'
 import { NamespaceDetailBody } from '@/features/namespaces/NamespaceDetailBody'
 import { ServiceAccountDetailBody } from '@/features/serviceaccounts/ServiceAccountDetailBody'
@@ -188,6 +191,12 @@ export function ResourceDetailPanel({ contextName, resource }: Props) {
             <div className="flex shrink-0 items-center gap-2 pt-1">
               {resource.kind === 'Pod' && (
                 <PortForwardButton contextName={contextName} resource={resource} />
+              )}
+              {!readOnly && resource.kind === 'Node' && (
+                <>
+                  <CordonNodeButton contextName={contextName} resource={resource} />
+                  <DrainNodeButton contextName={contextName} resource={resource} />
+                </>
               )}
               {!readOnly && isPausable(resource.kind) && (
                 <PauseDeploymentButton contextName={contextName} resource={resource} />
@@ -745,12 +754,17 @@ function CustomResourceTabs({ contextName, resource }: { contextName: string | n
 }
 
 function NonPodTabs({ contextName, resource }: { contextName: string | null; resource: SelectedResource }) {
+  const readOnly = useUIStore((s) => s.globalReadOnly)
   const hasAggregatedLogs = (WORKLOAD_LOG_KINDS as readonly string[]).includes(resource.kind)
   const hasEvents = (EVENT_BEARING_KINDS as readonly string[]).includes(resource.kind)
   const hasHistory = (ROLLOUT_HISTORY_KINDS as readonly string[]).includes(resource.kind)
+  // The node shell works through a temporary privileged pod, so it is a
+  // mutation and stays hidden in read-only mode.
+  const hasNodeShell = resource.kind === 'Node' && !readOnly
   const requestedTab = useUIStore((s) => s.requestedTab)
   const allowed: DetailTab[] = ['overview']
   if (hasAggregatedLogs) allowed.push('logs')
+  if (hasNodeShell) allowed.push('shell')
   if (hasEvents) allowed.push('events')
   if (hasHistory) allowed.push('history')
   allowed.push('yaml')
@@ -762,6 +776,7 @@ function NonPodTabs({ contextName, resource }: { contextName: string | null; res
       <TabsList className="mx-6 mt-3 w-fit">
         <TabsTrigger value="overview">Overview</TabsTrigger>
         {hasAggregatedLogs && <TabsTrigger value="logs">Logs</TabsTrigger>}
+        {hasNodeShell && <TabsTrigger value="shell">Shell</TabsTrigger>}
         {hasEvents && <TabsTrigger value="events">Events</TabsTrigger>}
         {hasHistory && <TabsTrigger value="history">History</TabsTrigger>}
         <TabsTrigger value="yaml">YAML</TabsTrigger>
@@ -772,6 +787,11 @@ function NonPodTabs({ contextName, resource }: { contextName: string | null; res
       {hasAggregatedLogs && (
         <TabsContent value="logs" className="min-h-0 flex-1 p-0">
           <WorkloadLogs contextName={contextName} resource={resource} />
+        </TabsContent>
+      )}
+      {hasNodeShell && (
+        <TabsContent value="shell" className="min-h-0 flex-1 p-0">
+          <NodeShellTab contextName={contextName} nodeName={resource.name} />
         </TabsContent>
       )}
       {hasEvents && (

--- a/frontend/src/features/nodes/CordonNodeButton.tsx
+++ b/frontend/src/features/nodes/CordonNodeButton.tsx
@@ -1,0 +1,117 @@
+import { useMutation } from '@tanstack/react-query'
+import { Ban, CircleCheck } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { api } from '@/lib/api'
+import { useResources } from '@/store/resources'
+import type { SelectedResource } from '@/store/ui'
+
+type Props = {
+  contextName: string | null
+  resource: SelectedResource
+}
+
+export function CordonNodeButton({ contextName, resource }: Props) {
+  const [open, setOpen] = useState(false)
+  const unschedulable = useResources(
+    (s) =>
+      (contextName ? s.nodes[contextName] : undefined)
+        ?.find((n) => n.name === resource.name)
+        ?.status.includes('SchedulingDisabled') ?? false,
+  )
+  const cordon = !unschedulable
+
+  const mutate = useMutation({
+    mutationFn: async () => {
+      if (!contextName) throw new Error('no context')
+      await api.cordonNode(contextName, resource.name, cordon)
+    },
+    onSuccess: () => {
+      toast.success(`${cordon ? 'Cordoned' : 'Uncordoned'} node/${resource.name}`)
+      setOpen(false)
+    },
+  })
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="xs" variant="outline" onClick={() => setOpen(true)}>
+            {cordon ? <Ban /> : <CircleCheck />}
+            {cordon ? 'Cordon' : 'Uncordon'}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {cordon
+            ? 'Mark the node unschedulable — running pods are not touched'
+            : 'Allow new pods to be scheduled on this node again'}
+        </TooltipContent>
+      </Tooltip>
+      <AlertDialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) mutate.reset()
+          setOpen(next)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{cordon ? 'Cordon' : 'Uncordon'} node?</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-2">
+                <p>
+                  Sets <code className="font-mono text-xs">spec.unschedulable</code> to{' '}
+                  <code className="font-mono text-xs">{String(cordon)}</code> on{' '}
+                  <span className="font-mono text-xs allow-select">node/{resource.name}</span> —
+                  equivalent to{' '}
+                  <code className="font-mono text-xs">
+                    kubectl {cordon ? 'cordon' : 'uncordon'}
+                  </code>
+                  .{' '}
+                  {cordon
+                    ? 'New pods stop landing on the node; running pods keep running.'
+                    : 'The scheduler can place new pods on the node again.'}
+                </p>
+                {mutate.error && (
+                  <p className="rounded border border-destructive/40 bg-destructive/10 p-2 font-mono text-xs text-destructive break-words">
+                    {String(mutate.error)}
+                  </p>
+                )}
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={mutate.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={mutate.isPending}
+              onClick={(e) => {
+                e.preventDefault()
+                mutate.mutate()
+              }}
+            >
+              {mutate.isPending
+                ? cordon
+                  ? 'Cordoning…'
+                  : 'Uncordoning…'
+                : cordon
+                  ? 'Cordon'
+                  : 'Uncordon'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/frontend/src/features/nodes/DrainNodeButton.tsx
+++ b/frontend/src/features/nodes/DrainNodeButton.tsx
@@ -1,0 +1,153 @@
+import { MoveDownLeft } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { EventsOn } from '@/lib/wails/wailsjs/runtime/runtime'
+import { api, type NodeDrainProgress } from '@/lib/api'
+import type { SelectedResource } from '@/store/ui'
+
+const PENDING_PREVIEW = 6
+
+type Props = {
+  contextName: string | null
+  resource: SelectedResource
+}
+
+export function DrainNodeButton({ contextName, resource }: Props) {
+  const [open, setOpen] = useState(false)
+  const [progress, setProgress] = useState<NodeDrainProgress | null>(null)
+  const [startError, setStartError] = useState<string | null>(null)
+  const unsubRef = useRef<(() => void) | null>(null)
+
+  const draining =
+    progress !== null && progress.phase !== 'done' && progress.phase !== 'error'
+
+  useEffect(
+    () => () => {
+      unsubRef.current?.()
+      unsubRef.current = null
+    },
+    [],
+  )
+
+  const start = () => {
+    if (!contextName) return
+    setStartError(null)
+    setProgress({ node: resource.name, phase: 'cordoning', total: 0, evicted: 0, pending: [], error: '' })
+    unsubRef.current?.()
+    unsubRef.current = EventsOn(
+      `node:drain:${contextName}/${resource.name}`,
+      (p: NodeDrainProgress) => {
+        setProgress(p)
+        if (p.phase === 'done') {
+          toast.success(`Drained node/${resource.name}`, {
+            description: `${p.total} pod(s) evicted. The node stays cordoned.`,
+          })
+          unsubRef.current?.()
+          unsubRef.current = null
+        }
+        if (p.phase === 'error') {
+          unsubRef.current?.()
+          unsubRef.current = null
+        }
+      },
+    )
+    api.drainNode(contextName, resource.name).catch((e: unknown) => {
+      setStartError(String(e))
+      setProgress(null)
+      unsubRef.current?.()
+      unsubRef.current = null
+    })
+  }
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="xs" variant="outline" onClick={() => setOpen(true)}>
+            <MoveDownLeft />
+            Drain
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Cordon the node, then evict every pod onto other nodes</TooltipContent>
+      </Tooltip>
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Drain node?</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-2">
+                <p>
+                  Cordons <span className="font-mono text-xs allow-select">node/{resource.name}</span>{' '}
+                  and evicts all pods through the Eviction API, so PodDisruptionBudgets are
+                  honored. DaemonSet-managed and static pods are left in place — equivalent to{' '}
+                  <code className="font-mono text-xs">
+                    kubectl drain --ignore-daemonsets --delete-emptydir-data --force
+                  </code>
+                  .
+                </p>
+                {progress && (
+                  <div className="space-y-1 rounded border border-border bg-muted/40 p-2 font-mono text-xs">
+                    <p>
+                      {progress.phase === 'done'
+                        ? `done — ${progress.total} pod(s) evicted`
+                        : progress.phase === 'error'
+                          ? 'failed'
+                          : `${progress.phase} — ${progress.evicted}/${progress.total} pod(s) gone`}
+                    </p>
+                    {progress.pending.length > 0 && progress.phase !== 'done' && (
+                      <p className="text-muted-foreground break-words">
+                        waiting on:{' '}
+                        {progress.pending.slice(0, PENDING_PREVIEW).join(', ')}
+                        {progress.pending.length > PENDING_PREVIEW &&
+                          ` +${progress.pending.length - PENDING_PREVIEW} more`}
+                      </p>
+                    )}
+                    {progress.error && (
+                      <p className="text-destructive break-words">{progress.error}</p>
+                    )}
+                  </div>
+                )}
+                {startError && (
+                  <p className="rounded border border-destructive/40 bg-destructive/10 p-2 font-mono text-xs text-destructive break-words">
+                    {startError}
+                  </p>
+                )}
+                {draining && (
+                  <p className="text-xs text-muted-foreground">
+                    Closing this dialog does not stop the drain.
+                  </p>
+                )}
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{draining || progress?.phase === 'done' ? 'Close' : 'Cancel'}</AlertDialogCancel>
+            {progress?.phase !== 'done' && (
+              <AlertDialogAction
+                disabled={draining || !contextName}
+                onClick={(e) => {
+                  e.preventDefault()
+                  start()
+                }}
+              >
+                {draining ? 'Draining…' : progress?.phase === 'error' ? 'Retry drain' : 'Drain'}
+              </AlertDialogAction>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/frontend/src/features/nodes/NodeShellTab.tsx
+++ b/frontend/src/features/nodes/NodeShellTab.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState } from 'react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
+import { EventsOff, EventsOn } from '@/lib/wails/wailsjs/runtime/runtime'
+import { Button } from '@/components/ui/button'
+import { api } from '@/lib/api'
+import { xtermThemeFor } from '@/features/_shared/xtermTheme'
+import { useUIStore } from '@/store/ui'
+
+type Props = {
+  contextName: string | null
+  nodeName: string
+}
+
+export function NodeShellTab({ contextName, nodeName }: Props) {
+  const fallbackContext = useUIStore((s) => s.selectedContext)
+  const selectedContext = contextName ?? fallbackContext
+  const themeId = useUIStore((s) => s.themeId)
+  const [running, setRunning] = useState(false)
+  const [starting, setStarting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [nonce, setNonce] = useState(0) // bumps to restart session
+
+  const termHostRef = useRef<HTMLDivElement>(null)
+  const termRef = useRef<Terminal | null>(null)
+  const fitRef = useRef<FitAddon | null>(null)
+  const sessionRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!termHostRef.current) return
+    const term = new Terminal({
+      cursorBlink: true,
+      convertEol: false,
+      fontFamily:
+        '"JetBrains Mono", "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+      fontSize: 12,
+      scrollback: 5_000,
+      theme: xtermThemeFor(themeId),
+    })
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    term.open(termHostRef.current)
+    fit.fit()
+    termRef.current = term
+    fitRef.current = fit
+
+    const observer = new ResizeObserver(() => {
+      try {
+        fit.fit()
+        if (sessionRef.current) {
+          api.resizeExec(sessionRef.current, term.cols, term.rows).catch(() => {})
+        }
+      } catch {
+        // ignore
+      }
+    })
+    observer.observe(termHostRef.current)
+
+    const dataDisposable = term.onData((data) => {
+      if (sessionRef.current) {
+        api.sendExecInput(sessionRef.current, data).catch(() => {})
+      }
+    })
+
+    return () => {
+      observer.disconnect()
+      dataDisposable.dispose()
+      term.dispose()
+      termRef.current = null
+      fitRef.current = null
+    }
+    // theme is applied via a separate effect to avoid recreating the terminal
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (termRef.current) {
+      termRef.current.options.theme = xtermThemeFor(themeId)
+    }
+  }, [themeId])
+
+  useEffect(() => {
+    const term = termRef.current
+    if (!selectedContext || !term) return
+
+    term.clear()
+    term.writeln(
+      `\x1b[2m# starting a privileged shell pod on ${nodeName} — image pull may take a moment…\x1b[0m`,
+    )
+
+    let cancelled = false
+    let unsubOut: (() => void) | null = null
+    let unsubClose: (() => void) | null = null
+    setStarting(true)
+
+    api
+      .startNodeShell(selectedContext, nodeName)
+      .then((id) => {
+        if (cancelled) {
+          api.stopExec(id).catch(() => {})
+          return
+        }
+        sessionRef.current = id
+        setStarting(false)
+        setRunning(true)
+        setError(null)
+        unsubOut = EventsOn(`exec:out:${id}`, (data: string) => {
+          term.write(data)
+        })
+        unsubClose = EventsOn(`exec:close:${id}`, (msg: string) => {
+          setRunning(false)
+          sessionRef.current = null
+          if (msg) {
+            term.writeln(`\r\n\x1b[31m# shell closed: ${msg}\x1b[0m`)
+          } else {
+            term.writeln(`\r\n\x1b[2m# shell ended — the helper pod was removed\x1b[0m`)
+          }
+        })
+        api.resizeExec(id, term.cols, term.rows).catch(() => {})
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return
+        setError(String(e))
+        setStarting(false)
+        setRunning(false)
+      })
+
+    return () => {
+      cancelled = true
+      unsubOut?.()
+      unsubClose?.()
+      const id = sessionRef.current
+      sessionRef.current = null
+      if (id) {
+        api.stopExec(id).catch(() => {})
+        EventsOff(`exec:out:${id}`, `exec:close:${id}`)
+      }
+    }
+  }, [selectedContext, nodeName, nonce])
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center gap-3 border-b border-border px-4 py-2 text-xs">
+        <span className="text-muted-foreground">
+          Root shell via a temporary privileged pod (<code>nsenter</code> into the host) —
+          removed when the session ends.
+        </span>
+        <Button
+          type="button"
+          size="xs"
+          variant="outline"
+          onClick={() => setNonce((n) => n + 1)}
+          className="ml-auto"
+        >
+          Reattach
+        </Button>
+        <span
+          className={
+            running ? 'text-emerald-500' : starting ? 'text-amber-500' : 'text-muted-foreground'
+          }
+        >
+          {running ? '● running' : starting ? '◌ starting' : '○ idle'}
+        </span>
+      </div>
+      {error && (
+        <div className="border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-xs font-mono text-destructive break-words">
+          {error}
+        </div>
+      )}
+      <div ref={termHostRef} className="min-h-0 flex-1 bg-background px-2 py-1" />
+    </div>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -71,6 +71,9 @@ import {
   GetJob,
   GetNamespace,
   GetNode,
+  StartNodeShell,
+  CordonNode,
+  DrainNode,
   GetPod,
   GetResourceYAML,
   GetSecret,
@@ -378,6 +381,17 @@ export type IngressRuleDetail = kube.IngressRuleDetail
 export type IngressPathDetail = kube.IngressPathDetail
 export type IngressTLSDetail = kube.IngressTLSDetail
 export type NodeDetail = kube.NodeDetail
+
+// Mirrors kube.NodeDrainProgress, which only travels over the
+// "node:drain:<context>/<node>" Wails event and so never lands in models.ts.
+export type NodeDrainProgress = {
+  node: string
+  phase: 'cordoning' | 'evicting' | 'waiting' | 'done' | 'error'
+  total: number
+  evicted: number
+  pending: string[]
+  error: string
+}
 export type NodeTaintDetail = kube.NodeTaintDetail
 export type NamespaceDetail = kube.NamespaceDetail
 export type ServiceAccountDetail = kube.ServiceAccountDetail
@@ -714,6 +728,11 @@ export const api = {
   resizeExec: (sessionId: string, cols: number, rows: number): Promise<void> =>
     ResizeExec(sessionId, cols, rows),
   stopExec: (sessionId: string): Promise<void> => StopExec(sessionId),
+  startNodeShell: (contextName: string, nodeName: string): Promise<string> =>
+    StartNodeShell(contextName, nodeName),
+  cordonNode: (ctx: string, nodeName: string, cordon: boolean): Promise<void> =>
+    CordonNode(ctx, nodeName, cordon),
+  drainNode: (ctx: string, nodeName: string): Promise<void> => DrainNode(ctx, nodeName),
   openLocalTerminal: (contextName: string, cols: number, rows: number): Promise<string> =>
     OpenLocalTerminal(contextName, cols, rows),
   sendLocalTerminalInput: (sessionId: string, data: string): Promise<void> =>

--- a/frontend/src/lib/wails/wailsjs/go/app/App.d.ts
+++ b/frontend/src/lib/wails/wailsjs/go/app/App.d.ts
@@ -17,11 +17,15 @@ export function CertManagerOrdersFor(arg1:string,arg2:string,arg3:string):Promis
 
 export function CheckForUpdate():Promise<update.Result>;
 
+export function CordonNode(arg1:string,arg2:string,arg3:boolean):Promise<void>;
+
 export function DeleteArgoApplication(arg1:string,arg2:string,arg3:string,arg4:string):Promise<void>;
 
 export function DeleteResource(arg1:string,arg2:string,arg3:string,arg4:string):Promise<void>;
 
 export function DenyCertificateSigningRequest(arg1:string,arg2:string,arg3:string):Promise<void>;
+
+export function DrainNode(arg1:string,arg2:string):Promise<void>;
 
 export function DryRunApplyResourceYAML(arg1:string,arg2:string):Promise<kube.MutationDiff>;
 
@@ -466,6 +470,8 @@ export function SetFluxResourceSuspended(arg1:string,arg2:string,arg3:string,arg
 export function SetReadOnly(arg1:string,arg2:boolean):Promise<void>;
 
 export function StartExec(arg1:string,arg2:string,arg3:string,arg4:string,arg5:Array<string>):Promise<string>;
+
+export function StartNodeShell(arg1:string,arg2:string):Promise<string>;
 
 export function StartPodLogs(arg1:string,arg2:string,arg3:string,arg4:string,arg5:boolean,arg6:number):Promise<string>;
 

--- a/frontend/src/lib/wails/wailsjs/go/app/App.js
+++ b/frontend/src/lib/wails/wailsjs/go/app/App.js
@@ -30,6 +30,10 @@ export function CheckForUpdate() {
   return window['go']['app']['App']['CheckForUpdate']();
 }
 
+export function CordonNode(arg1, arg2, arg3) {
+  return window['go']['app']['App']['CordonNode'](arg1, arg2, arg3);
+}
+
 export function DeleteArgoApplication(arg1, arg2, arg3, arg4) {
   return window['go']['app']['App']['DeleteArgoApplication'](arg1, arg2, arg3, arg4);
 }
@@ -40,6 +44,10 @@ export function DeleteResource(arg1, arg2, arg3, arg4) {
 
 export function DenyCertificateSigningRequest(arg1, arg2, arg3) {
   return window['go']['app']['App']['DenyCertificateSigningRequest'](arg1, arg2, arg3);
+}
+
+export function DrainNode(arg1, arg2) {
+  return window['go']['app']['App']['DrainNode'](arg1, arg2);
 }
 
 export function DryRunApplyResourceYAML(arg1, arg2) {
@@ -928,6 +936,10 @@ export function SetReadOnly(arg1, arg2) {
 
 export function StartExec(arg1, arg2, arg3, arg4, arg5) {
   return window['go']['app']['App']['StartExec'](arg1, arg2, arg3, arg4, arg5);
+}
+
+export function StartNodeShell(arg1, arg2) {
+  return window['go']['app']['App']['StartNodeShell'](arg1, arg2);
 }
 
 export function StartPodLogs(arg1, arg2, arg3, arg4, arg5, arg6) {

--- a/frontend/src/store/ui.types.ts
+++ b/frontend/src/store/ui.types.ts
@@ -219,7 +219,7 @@ export type SelectedResource = {
   logContainer?: string
 }
 
-export type DetailTab = 'overview' | 'logs' | 'exec' | 'events' | 'history' | 'yaml'
+export type DetailTab = 'overview' | 'logs' | 'exec' | 'shell' | 'events' | 'history' | 'yaml'
 
 export type PendingAction =
   | { kind: 'delete'; resource: SelectedResource }

--- a/internal/kube/manager.go
+++ b/internal/kube/manager.go
@@ -46,6 +46,8 @@ type ClientManager struct {
 	helm     *helmManager
 	onChange func(ContextChange)
 	readOnly map[string]bool
+	drainMu  sync.Mutex
+	draining map[string]bool
 }
 
 func NewClientManager() *ClientManager {
@@ -62,6 +64,7 @@ func NewClientManager() *ClientManager {
 		metrics:  newMetricsCache(),
 		helm:     helm,
 		readOnly: make(map[string]bool),
+		draining: make(map[string]bool),
 	}
 }
 

--- a/internal/kube/nodeops.go
+++ b/internal/kube/nodeops.go
@@ -1,0 +1,186 @@
+package kube
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func (m *ClientManager) SetNodeCordon(ctx context.Context, contextName, nodeName string, cordon bool) error {
+	if err := m.assertWritable(contextName); err != nil {
+		return err
+	}
+	cs, err := m.Clientset(contextName)
+	if err != nil {
+		return err
+	}
+	patch, err := json.Marshal(map[string]any{"spec": map[string]any{"unschedulable": cordon}})
+	if err != nil {
+		return err
+	}
+	_, err = cs.CoreV1().Nodes().Patch(
+		ctx, nodeName, types.MergePatchType, patch,
+		metav1.PatchOptions{FieldManager: "klustr"},
+	)
+	return err
+}
+
+// NodeDrainProgress is streamed to the frontend while a drain runs. Phase is
+// one of cordoning / evicting / waiting / done; Pending holds "ns/name" of
+// pods still on the node; Error carries the most recent eviction failure
+// (e.g. a PDB block) without stopping the drain.
+type NodeDrainProgress struct {
+	Node    string   `json:"node"`
+	Phase   string   `json:"phase"`
+	Total   int      `json:"total"`
+	Evicted int      `json:"evicted"`
+	Pending []string `json:"pending"`
+	Error   string   `json:"error"`
+}
+
+const drainPollInterval = 2 * time.Second
+
+// DrainNode cordons the node, then evicts every pod except DaemonSet-managed
+// and static mirror pods through the policy/v1 Eviction API — so
+// PodDisruptionBudgets are honored, with blocked evictions retried each poll
+// round. It blocks until the node is empty or ctx is done; callers run it in
+// a goroutine and consume onProgress.
+func (m *ClientManager) DrainNode(ctx context.Context, contextName, nodeName string, onProgress func(NodeDrainProgress)) error {
+	if err := m.assertWritable(contextName); err != nil {
+		return err
+	}
+
+	key := contextName + "/" + nodeName
+	m.drainMu.Lock()
+	if m.draining[key] {
+		m.drainMu.Unlock()
+		return fmt.Errorf("a drain of node %q is already running", nodeName)
+	}
+	m.draining[key] = true
+	m.drainMu.Unlock()
+	defer func() {
+		m.drainMu.Lock()
+		delete(m.draining, key)
+		m.drainMu.Unlock()
+	}()
+
+	cs, err := m.Clientset(contextName)
+	if err != nil {
+		return err
+	}
+	report := func(p NodeDrainProgress) {
+		if onProgress == nil {
+			return
+		}
+		p.Node = nodeName
+		if p.Pending == nil {
+			p.Pending = []string{}
+		}
+		onProgress(p)
+	}
+
+	report(NodeDrainProgress{Phase: "cordoning"})
+	if err := m.SetNodeCordon(ctx, contextName, nodeName, true); err != nil {
+		return fmt.Errorf("cordon: %w", err)
+	}
+
+	list, err := cs.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		return err
+	}
+	targets := drainTargets(list.Items)
+	total := len(targets)
+	report(NodeDrainProgress{Phase: "evicting", Total: total, Pending: podKeys(targets)})
+
+	for {
+		pending := make([]corev1.Pod, 0, len(targets))
+		for _, p := range targets {
+			cur, err := cs.CoreV1().Pods(p.Namespace).Get(ctx, p.Name, metav1.GetOptions{})
+			switch {
+			case apierrors.IsNotFound(err):
+			case err == nil && cur.UID != p.UID:
+				// Same name, new pod: the controller recreated it elsewhere
+				// (the cordon keeps it off this node) — the original is gone.
+			case err != nil:
+				pending = append(pending, p)
+			default:
+				pending = append(pending, *cur)
+			}
+		}
+		if len(pending) == 0 {
+			report(NodeDrainProgress{Phase: "done", Total: total, Evicted: total})
+			return nil
+		}
+
+		evictErr := ""
+		for _, p := range pending {
+			if p.DeletionTimestamp != nil {
+				continue
+			}
+			err := cs.PolicyV1().Evictions(p.Namespace).Evict(ctx, &policyv1.Eviction{
+				ObjectMeta: metav1.ObjectMeta{Name: p.Name, Namespace: p.Namespace},
+			})
+			switch {
+			case err == nil, apierrors.IsNotFound(err):
+			case apierrors.IsTooManyRequests(err):
+				evictErr = fmt.Sprintf("%s/%s: blocked by a PodDisruptionBudget, retrying", p.Namespace, p.Name)
+			default:
+				evictErr = fmt.Sprintf("%s/%s: %v", p.Namespace, p.Name, err)
+			}
+		}
+
+		report(NodeDrainProgress{
+			Phase:   "waiting",
+			Total:   total,
+			Evicted: total - len(pending),
+			Pending: podKeys(pending),
+			Error:   evictErr,
+		})
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("drain interrupted with %d pod(s) still on the node: %w", len(pending), ctx.Err())
+		case <-time.After(drainPollInterval):
+		}
+	}
+}
+
+// drainTargets selects the pods a drain must evict: everything on the node
+// except DaemonSet-managed pods (their controller recreates them in place and
+// they tolerate the cordon anyway), static mirror pods (owned by the kubelet,
+// not evictable) and pods that already finished.
+func drainTargets(pods []corev1.Pod) []corev1.Pod {
+	out := make([]corev1.Pod, 0, len(pods))
+	for _, p := range pods {
+		if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		if _, mirror := p.Annotations[corev1.MirrorPodAnnotationKey]; mirror {
+			continue
+		}
+		if ref := metav1.GetControllerOf(&p); ref != nil && ref.Kind == "DaemonSet" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func podKeys(pods []corev1.Pod) []string {
+	keys := make([]string, 0, len(pods))
+	for _, p := range pods {
+		keys = append(keys, p.Namespace+"/"+p.Name)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/kube/nodeops_test.go
+++ b/internal/kube/nodeops_test.go
@@ -1,0 +1,84 @@
+package kube
+
+import (
+	"slices"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func drainPod(name string, mutate func(*corev1.Pod)) corev1.Pod {
+	p := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	if mutate != nil {
+		mutate(&p)
+	}
+	return p
+}
+
+func TestDrainTargets(t *testing.T) {
+	controller := true
+	pods := []corev1.Pod{
+		drainPod("app", nil),
+		drainPod("ds-managed", func(p *corev1.Pod) {
+			p.OwnerReferences = []metav1.OwnerReference{
+				{Kind: "DaemonSet", Name: "fluentd", Controller: &controller},
+			}
+		}),
+		drainPod("rs-managed", func(p *corev1.Pod) {
+			p.OwnerReferences = []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: "web-abc", Controller: &controller},
+			}
+		}),
+		drainPod("mirror", func(p *corev1.Pod) {
+			p.Annotations = map[string]string{corev1.MirrorPodAnnotationKey: "x"}
+		}),
+		drainPod("finished", func(p *corev1.Pod) {
+			p.Status.Phase = corev1.PodSucceeded
+		}),
+		drainPod("crashed", func(p *corev1.Pod) {
+			p.Status.Phase = corev1.PodFailed
+		}),
+	}
+
+	got := podKeys(drainTargets(pods))
+	want := []string{"default/app", "default/rs-managed"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("drainTargets = %v, want %v", got, want)
+	}
+}
+
+func TestPodKeysSorted(t *testing.T) {
+	pods := []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "kube-system"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "default"}},
+	}
+	got := podKeys(pods)
+	want := []string{"default/a", "kube-system/b"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("podKeys = %v, want %v", got, want)
+	}
+}
+
+func TestNodeShellPodSpec(t *testing.T) {
+	pod := nodeShellPod("worker-1")
+	if pod.Spec.NodeName != "worker-1" {
+		t.Fatalf("NodeName = %q, want worker-1", pod.Spec.NodeName)
+	}
+	if !pod.Spec.HostPID {
+		t.Fatal("node-shell pod must set hostPID for nsenter -t 1")
+	}
+	c := pod.Spec.Containers[0]
+	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
+		t.Fatal("node-shell container must be privileged")
+	}
+	if pod.Spec.ActiveDeadlineSeconds == nil || *pod.Spec.ActiveDeadlineSeconds <= 0 {
+		t.Fatal("node-shell pod must self-destruct via activeDeadlineSeconds")
+	}
+	if len(pod.Spec.Tolerations) == 0 || pod.Spec.Tolerations[0].Operator != corev1.TolerationOpExists {
+		t.Fatal("node-shell pod must tolerate every taint")
+	}
+}

--- a/internal/kube/nodeshell.go
+++ b/internal/kube/nodeshell.go
@@ -1,0 +1,172 @@
+package kube
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	nodeShellNamespace     = "kube-system"
+	nodeShellContainerName = "shell"
+	nodeShellImage         = "docker.io/library/alpine:3.22"
+	nodeShellReadyTimeout  = 90 * time.Second
+)
+
+// nodeShellCommand re-enters the host's namespaces through PID 1 and runs the
+// host's login shell, so the shell and every binary resolve from the host
+// filesystem, not the helper image. /bin/sh is the entry point because it
+// exists on every host (minimal node VMs such as OrbStack's ship no bash); the
+// -c probe upgrades to bash -l when the host has it, falling back to sh -l.
+//
+// nsenter options are the long form, not the short `-t 1 -m -u -i -n -p`
+// cluster: the helper image's busybox nsenter mis-parses the short
+// optional-arg form on some node runtimes, exec'ing the post-`--` program with
+// the wrong argv.
+var nodeShellCommand = []string{
+	"nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid", "--",
+	"sh", "-c",
+	"if command -v bash >/dev/null 2>&1; then exec bash -l; else exec sh -l; fi",
+}
+
+// StartNodeShell gives a root shell on the node by creating a privileged
+// hostPID pod pinned to it and nsenter-ing into the host's namespaces — the
+// same approach as `kubectl node-shell` and Lens. The pod is deleted when the
+// session ends; ActiveDeadlineSeconds is the safety net if Klustr dies first.
+func (m *ClientManager) StartNodeShell(
+	parent context.Context,
+	contextName, nodeName string,
+	onData ExecDataFunc,
+	onClose ExecCloseFunc,
+) (string, error) {
+	if err := m.assertWritable(contextName); err != nil {
+		return "", err
+	}
+	cs, err := m.Clientset(contextName)
+	if err != nil {
+		return "", err
+	}
+	cfg, err := m.restConfig(contextName)
+	if err != nil {
+		return "", err
+	}
+
+	created, err := cs.CoreV1().Pods(nodeShellNamespace).Create(
+		parent, nodeShellPod(nodeName), metav1.CreateOptions{FieldManager: "klustr"})
+	if err != nil {
+		return "", fmt.Errorf("create node-shell pod: %w", err)
+	}
+
+	if err := waitPodRunning(parent, cs, nodeShellNamespace, created.Name, nodeShellReadyTimeout); err != nil {
+		deleteNodeShellPod(cs, created.Name)
+		return "", err
+	}
+
+	id, err := m.execs.start(
+		parent, cfg, cs, nodeShellNamespace, created.Name, nodeShellContainerName, nodeShellCommand,
+		onData,
+		func(err error) {
+			deleteNodeShellPod(cs, created.Name)
+			if onClose != nil {
+				onClose(err)
+			}
+		},
+	)
+	if err != nil {
+		deleteNodeShellPod(cs, created.Name)
+		return "", err
+	}
+	return id, nil
+}
+
+func nodeShellPod(nodeName string) *corev1.Pod {
+	privileged := true
+	noGrace := int64(0)
+	deadline := int64(4 * 60 * 60)
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("klustr-node-shell-%s", utilrand.String(5)),
+			Namespace: nodeShellNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "klustr",
+				"klustr/component":             "node-shell",
+			},
+		},
+		Spec: corev1.PodSpec{
+			// Pinning spec.nodeName bypasses the scheduler, so a cordoned
+			// node can still be shelled into.
+			NodeName:                      nodeName,
+			HostPID:                       true,
+			HostIPC:                       true,
+			HostNetwork:                   true,
+			RestartPolicy:                 corev1.RestartPolicyNever,
+			TerminationGracePeriodSeconds: &noGrace,
+			ActiveDeadlineSeconds:         &deadline,
+			Tolerations:                   []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+			Containers: []corev1.Container{{
+				Name:            nodeShellContainerName,
+				Image:           nodeShellImage,
+				Command:         []string{"sleep", "14400"},
+				SecurityContext: &corev1.SecurityContext{Privileged: &privileged},
+			}},
+		},
+	}
+}
+
+func waitPodRunning(ctx context.Context, cs kubernetes.Interface, namespace, name string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	lastState := "Pending"
+	for {
+		pod, err := cs.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("node-shell pod %q disappeared while starting", name)
+		}
+		if err == nil {
+			switch pod.Status.Phase {
+			case corev1.PodRunning:
+				return nil
+			case corev1.PodSucceeded, corev1.PodFailed:
+				return fmt.Errorf("node-shell pod %q exited before attach (%s)", name, podStartState(pod))
+			}
+			lastState = podStartState(pod)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for node-shell pod %q to start (%s)", name, lastState)
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func podStartState(pod *corev1.Pod) string {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if w := cs.State.Waiting; w != nil && w.Reason != "" {
+			return w.Reason
+		}
+		if t := cs.State.Terminated; t != nil && t.Reason != "" {
+			return t.Reason
+		}
+	}
+	if pod.Status.Reason != "" {
+		return pod.Status.Reason
+	}
+	return string(pod.Status.Phase)
+}
+
+// deleteNodeShellPod is fire-and-forget: the session is already over, so the
+// user has nothing to wait on, and ActiveDeadlineSeconds covers a lost delete.
+func deleteNodeShellPod(cs kubernetes.Interface, name string) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		noGrace := int64(0)
+		_ = cs.CoreV1().Pods(nodeShellNamespace).Delete(ctx, name, metav1.DeleteOptions{GracePeriodSeconds: &noGrace})
+	}()
+}


### PR DESCRIPTION
## What

Brings node-level operations to Klustr — the table-stakes gap versus Lens, Freelens and Aptakube, which all ship these.

- **Node shell** — a **Shell** tab on the node detail opens a root shell on the node via a temporary node-pinned, `hostPID` privileged helper pod that `nsenter`s into PID 1's namespaces (the `kubectl node-shell` / Lens approach). The pod is removed when the session ends and self-destructs via `activeDeadlineSeconds` if Klustr dies first. No SSH, nothing pre-installed — it drives the standard `pods/exec` API. Uses the host's `bash` when present, falling back to `sh` (minimal node VMs ship no bash).
- **Cordon / Uncordon** — header button that patches `spec.unschedulable`, label flips with the node's live state.
- **Drain** — cordons, then evicts every pod through the `policy/v1` Eviction API so **PodDisruptionBudgets are honored**, skipping DaemonSet-managed and static mirror pods and retrying PDB-blocked evictions each poll round. Live progress (phase, evicted/total, pods still pending) streams into the dialog; closing it does not stop the drain.

All three are hidden in read-only mode and gated by `assertWritable` on the backend.

## How it's built

- `internal/kube/nodeshell.go` — helper pod spec + attach through the existing `execSessionManager`.
- `internal/kube/nodeops.go` — cordon patch and the eviction-loop drain with streamed progress; `nodeops_test.go` covers `drainTargets` selection and the pod spec invariants.
- `app/app.go` — `StartNodeShell` / `CordonNode` / `DrainNode`; drain runs in a goroutine and streams over a per-node Wails event.
- `frontend/src/features/nodes/` — `NodeShellTab`, `CordonNodeButton`, `DrainNodeButton`.

## Testing

- `go test klustr/internal/...` + `go vet ./...` pass.
- Frontend `npm test` / `lint` / `typecheck` pass.
- Manually verified in `wails dev` against a real EKS cluster (shell lands on the host as root, bash prompt) and a local OrbStack cluster (falls back to `sh`). Cordon, uncordon and drain exercised on a multi-node cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)