### PR TITLE
feat: in-place pod resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Klustr is a cross-platform Kubernetes desktop client built with [Wails](https://
 - 🚧 **Cordon & drain.** One-click cordon/uncordon and a live-progress drain that evicts through the Eviction API (PDB-aware, skips DaemonSet & mirror pods).
 - 🔧 **YAML edit.** Monaco editor with a server-side dry-run diff before apply.
 - 🚀 **Scale, restart, pause/resume.** Replica controls, one-click rolling restart, inline pause/resume, HPA min/max editable inline.
+- 📐 **In-place pod resize.** Change a running container's CPU / memory requests and limits via the `pods/resize` subresource — no pod recreation; shows the live resize status (Deferred / Infeasible).
 - ⏪ **Rollout history & rollback.** Side-by-side template diff and one-click revert on Deployments / StatefulSets / DaemonSets.
 - 🔄 **Port-forwarding.** Suggested local ports, persistent header indicator, click-to-open in browser.
 - 🗺️ **Cluster overviews.** CPU / memory / pod donuts, workloads health, recent warnings — single-cluster or aggregated.
@@ -194,6 +195,7 @@ Full design notes, conventions and the "add a new resource kind" recipe live in 
 - [x] Logs, exec, port-forwarding
 - [x] Node shell (privileged `nsenter` pod), cordon/uncordon, PDB-aware drain
 - [x] YAML edit / apply with diff, scale, restart, deployment pause/resume, HPA inline edit
+- [x] In-place pod resize (CPU/memory requests & limits via the `pods/resize` subresource, no recreation)
 - [x] Rollout history with revision diff and one-click rollback (Deployments / StatefulSets / DaemonSets)
 - [x] Cross-resource navigation (related pods, owner/node links, back stack)
 - [x] Custom Resource Definitions (CRDs)

--- a/app/app.go
+++ b/app/app.go
@@ -272,6 +272,10 @@ func (a *App) PatchHPAReplicas(contextName, namespace, name string, minReplicas,
 	return a.clients.PatchHPAReplicas(a.ctx, contextName, namespace, name, int32(minReplicas), int32(maxReplicas))
 }
 
+func (a *App) ResizePodResources(contextName, namespace, podName, container, cpuRequest, cpuLimit, memRequest, memLimit string) error {
+	return a.clients.ResizePodResources(a.ctx, contextName, namespace, podName, container, cpuRequest, cpuLimit, memRequest, memLimit)
+}
+
 func (a *App) PatchDeploymentPaused(contextName, namespace, name string, paused bool) error {
 	return a.clients.PatchDeploymentPaused(a.ctx, contextName, namespace, name, paused)
 }

--- a/frontend/src/features/_shared/ResourceDetailPanel.tsx
+++ b/frontend/src/features/_shared/ResourceDetailPanel.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/features/argocd/DeleteArgoApplicationButton'
 import { SyncArgoApplicationButton } from '@/features/argocd/SyncArgoApplicationButton'
 import { PodExecTab } from '@/features/pods/PodExecTab'
+import { ResizePodButton } from '@/features/pods/ResizePodButton'
 import { DeploymentDetailBody } from '@/features/deployments/DeploymentDetailBody'
 import { StatefulSetDetailBody } from '@/features/statefulsets/StatefulSetDetailBody'
 import { DaemonSetDetailBody } from '@/features/daemonsets/DaemonSetDetailBody'
@@ -189,6 +190,13 @@ export function ResourceDetailPanel({ contextName, resource }: Props) {
           </div>
           {resource && resource.kind !== 'HelmRelease' && (
             <div className="flex shrink-0 items-center gap-2 pt-1">
+              {!readOnly && resource.kind === 'Pod' && (
+                <ResizePodButton
+                  contextName={contextName}
+                  namespace={resource.namespace}
+                  podName={resource.name}
+                />
+              )}
               {resource.kind === 'Pod' && (
                 <PortForwardButton contextName={contextName} resource={resource} />
               )}

--- a/frontend/src/features/pods/PodOverviewBody.tsx
+++ b/frontend/src/features/pods/PodOverviewBody.tsx
@@ -22,6 +22,7 @@ export function PodOverviewBody({
   return (
     <div className="space-y-6">
       <PodDiagnosisCard detail={detail} />
+      {detail.resizeStatus && <ResizeStatusBanner status={detail.resizeStatus} />}
       <div className="grid gap-6 sm:grid-cols-2">
         <Section title="Status">
           <Field label="Status">{detail.status}</Field>
@@ -398,6 +399,37 @@ function SecretEnvValue({
   )
 }
 
+function ResizeStatusBanner({ status }: { status: string }) {
+  const infeasible = status === 'Infeasible'
+  return (
+    <div
+      className={[
+        'rounded-md border px-4 py-2 text-xs',
+        infeasible
+          ? 'border-destructive/40 bg-destructive/5 text-destructive'
+          : 'border-amber-500/40 bg-amber-500/5 text-amber-700 dark:text-amber-400',
+      ].join(' ')}
+    >
+      In-place resize <span className="font-semibold">{status}</span>
+      {infeasible
+        ? " — the node can't satisfy the requested resources."
+        : status === 'Deferred'
+          ? ' — waiting for room on the node; will retry.'
+          : ' — the kubelet is applying the new resources.'}
+    </div>
+  )
+}
+
+function resourceCell(req: string, lim: string) {
+  if (!req && !lim) return <span className="text-muted-foreground">—</span>
+  return (
+    <span className="font-mono">
+      {req || '—'}
+      <span className="text-muted-foreground"> / {lim || '—'}</span>
+    </span>
+  )
+}
+
 function PodContainersTable({
   title,
   containers,
@@ -406,7 +438,10 @@ function PodContainersTable({
   containers: PodDetail['containers']
 }) {
   return (
-    <Section title={title}>
+    <section className="rounded-md border border-border bg-card/40 p-4">
+      <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {title}
+      </h3>
       <div className="overflow-hidden rounded border border-border">
         <table className="w-full text-xs">
           <thead className="bg-muted/40 text-muted-foreground">
@@ -416,6 +451,8 @@ function PodContainersTable({
               <Th>State</Th>
               <Th>Ready</Th>
               <Th>Restarts</Th>
+              <Th>CPU req/lim</Th>
+              <Th>Mem req/lim</Th>
             </tr>
           </thead>
           <tbody>
@@ -429,11 +466,13 @@ function PodContainersTable({
                 </Td>
                 <Td>{c.ready ? '✓' : '·'}</Td>
                 <Td>{c.restartCount}</Td>
+                <Td>{resourceCell(c.resources?.cpuRequest ?? '', c.resources?.cpuLimit ?? '')}</Td>
+                <Td>{resourceCell(c.resources?.memRequest ?? '', c.resources?.memLimit ?? '')}</Td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
-    </Section>
+    </section>
   )
 }

--- a/frontend/src/features/pods/ResizePodButton.tsx
+++ b/frontend/src/features/pods/ResizePodButton.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { Scaling } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Spinner } from '@/components/ui/spinner'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { InlinePicker } from '@/features/_shared/InlinePicker'
+import { api, type ContainerDetail } from '@/lib/api'
+
+type Props = {
+  contextName: string | null
+  namespace: string
+  podName: string
+}
+
+type Fields = {
+  cpuRequest: string
+  cpuLimit: string
+  memRequest: string
+  memLimit: string
+}
+
+function fieldsFor(c: ContainerDetail | undefined): Fields {
+  return {
+    cpuRequest: c?.resources?.cpuRequest ?? '',
+    cpuLimit: c?.resources?.cpuLimit ?? '',
+    memRequest: c?.resources?.memRequest ?? '',
+    memLimit: c?.resources?.memLimit ?? '',
+  }
+}
+
+export function ResizePodButton({ contextName, namespace, podName }: Props) {
+  const [open, setOpen] = useState(false)
+  const [containers, setContainers] = useState<ContainerDetail[]>([])
+  const [loading, setLoading] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [container, setContainer] = useState('')
+  const [fields, setFields] = useState<Fields>(fieldsFor(undefined))
+
+  const names = containers.map((c) => c.name)
+  const current = containers.find((c) => c.name === container)
+
+  useEffect(() => {
+    if (!open || !contextName) return
+    let cancelled = false
+    setLoading(true)
+    setLoadError(null)
+    api
+      .getPod(contextName, namespace, podName)
+      .then((p) => {
+        if (cancelled) return
+        setContainers(p.containers)
+        const first = p.containers[0]
+        setContainer(first?.name ?? '')
+        setFields(fieldsFor(first))
+      })
+      .catch((e) => {
+        if (cancelled) return
+        setLoadError(String(e))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, contextName, namespace, podName])
+
+  const selectContainer = (name: string) => {
+    setContainer(name)
+    setFields(fieldsFor(containers.find((c) => c.name === name)))
+  }
+
+  const set = (key: keyof Fields) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setFields((f) => ({ ...f, [key]: e.target.value }))
+
+  const resize = useMutation({
+    mutationFn: async () => {
+      if (!contextName) throw new Error('no context')
+      await api.resizePodResources(
+        contextName,
+        namespace,
+        podName,
+        container,
+        fields.cpuRequest.trim(),
+        fields.cpuLimit.trim(),
+        fields.memRequest.trim(),
+        fields.memLimit.trim(),
+      )
+    },
+    onSuccess: () => {
+      toast.success(`Resized ${container} on pod/${podName}`, {
+        description: 'Applied in place via the resize subresource — watch the container status for the new allocation.',
+      })
+      setOpen(false)
+    },
+  })
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o)
+        if (o) resize.reset()
+      }}
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <Button size="xs" variant="outline">
+              <Scaling />
+              Resize
+            </Button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Change CPU / memory in place, without recreating the pod</TooltipContent>
+      </Tooltip>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Resize pod resources</DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-1">
+              <p>
+                Changes a running container's CPU / memory requests and limits in place via the{' '}
+                <code className="font-mono text-xs">pods/resize</code> subresource — the pod is not
+                recreated. Whether the container restarts is governed by its{' '}
+                <code className="font-mono text-xs">resizePolicy</code>.
+              </p>
+              <p>
+                Leave a field blank to keep it unchanged. The QoS class can't change, and the node
+                must have room or the request is deferred.
+              </p>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {loading && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Spinner size="sm" />
+              Loading current resources…
+            </div>
+          )}
+          {loadError && (
+            <p className="rounded border border-destructive/40 bg-destructive/10 p-2 font-mono text-xs text-destructive break-words">
+              {loadError}
+            </p>
+          )}
+
+          {names.length > 1 && (
+            <div className="flex items-center gap-3 text-xs">
+              <span className="text-muted-foreground">Container</span>
+              <InlinePicker
+                value={container}
+                options={names}
+                onChange={selectContainer}
+                ariaLabel="Select container"
+                minWidth={160}
+              />
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="CPU request" placeholder="e.g. 250m" value={fields.cpuRequest} onChange={set('cpuRequest')} />
+            <Field label="CPU limit" placeholder="e.g. 500m" value={fields.cpuLimit} onChange={set('cpuLimit')} />
+            <Field label="Memory request" placeholder="e.g. 128Mi" value={fields.memRequest} onChange={set('memRequest')} />
+            <Field label="Memory limit" placeholder="e.g. 256Mi" value={fields.memLimit} onChange={set('memLimit')} />
+          </div>
+
+          {current?.allocated && (current.allocated.cpuRequest || current.allocated.memRequest) && (
+            <p className="text-[11px] text-muted-foreground">
+              Currently allocated: CPU {current.allocated.cpuRequest || '—'}
+              {current.allocated.cpuLimit ? ` / ${current.allocated.cpuLimit}` : ''}, Memory{' '}
+              {current.allocated.memRequest || '—'}
+              {current.allocated.memLimit ? ` / ${current.allocated.memLimit}` : ''}
+            </p>
+          )}
+
+          {resize.error && (
+            <p className="rounded border border-destructive/40 bg-destructive/10 p-2 font-mono text-xs text-destructive break-words">
+              {String(resize.error)}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => setOpen(false)} disabled={resize.isPending}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => resize.mutate()}
+            disabled={resize.isPending || !contextName || loading || !container}
+          >
+            {resize.isPending ? 'Resizing…' : 'Resize'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Field({
+  label,
+  placeholder,
+  value,
+  onChange,
+}: {
+  label: string
+  placeholder: string
+  value: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+}) {
+  return (
+    <label className="space-y-1">
+      <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</span>
+      <Input value={value} onChange={onChange} placeholder={placeholder} className="font-mono" />
+    </label>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -228,6 +228,7 @@ import {
   GetWorkloadRevisionTemplate,
   PatchDeploymentPaused,
   PatchHPAReplicas,
+  ResizePodResources,
   RestartWorkload,
   ScaleResource,
   SendExecInput,
@@ -831,6 +832,17 @@ export const api = {
     minReplicas: number,
     maxReplicas: number,
   ): Promise<void> => PatchHPAReplicas(ctx, ns, name, minReplicas, maxReplicas),
+  resizePodResources: (
+    ctx: string,
+    ns: string,
+    podName: string,
+    container: string,
+    cpuRequest: string,
+    cpuLimit: string,
+    memRequest: string,
+    memLimit: string,
+  ): Promise<void> =>
+    ResizePodResources(ctx, ns, podName, container, cpuRequest, cpuLimit, memRequest, memLimit),
   patchDeploymentPaused: (ctx: string, ns: string, name: string, paused: boolean): Promise<void> =>
     PatchDeploymentPaused(ctx, ns, name, paused),
   listDeploymentRevisions: (ctx: string, ns: string, name: string): Promise<WorkloadRevision[]> =>

--- a/frontend/src/lib/wails/wailsjs/go/app/App.d.ts
+++ b/frontend/src/lib/wails/wailsjs/go/app/App.d.ts
@@ -439,6 +439,8 @@ export function ResizeExec(arg1:string,arg2:number,arg3:number):Promise<void>;
 
 export function ResizeLocalTerminal(arg1:string,arg2:number,arg3:number):Promise<void>;
 
+export function ResizePodResources(arg1:string,arg2:string,arg3:string,arg4:string,arg5:string,arg6:string,arg7:string,arg8:string):Promise<void>;
+
 export function RestartWorkload(arg1:string,arg2:string,arg3:string,arg4:string):Promise<void>;
 
 export function RevealSecretValue(arg1:string,arg2:string,arg3:string,arg4:string):Promise<string>;

--- a/frontend/src/lib/wails/wailsjs/go/app/App.js
+++ b/frontend/src/lib/wails/wailsjs/go/app/App.js
@@ -874,6 +874,10 @@ export function ResizeLocalTerminal(arg1, arg2, arg3) {
   return window['go']['app']['App']['ResizeLocalTerminal'](arg1, arg2, arg3);
 }
 
+export function ResizePodResources(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) {
+  return window['go']['app']['App']['ResizePodResources'](arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+}
+
 export function RestartWorkload(arg1, arg2, arg3, arg4) {
   return window['go']['app']['App']['RestartWorkload'](arg1, arg2, arg3, arg4);
 }

--- a/frontend/src/lib/wails/wailsjs/go/models.ts
+++ b/frontend/src/lib/wails/wailsjs/go/models.ts
@@ -1826,6 +1826,24 @@ export namespace kube {
 	        this.createdAt = source["createdAt"];
 	    }
 	}
+	export class ContainerResources {
+	    cpuRequest: string;
+	    cpuLimit: string;
+	    memRequest: string;
+	    memLimit: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new ContainerResources(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.cpuRequest = source["cpuRequest"];
+	        this.cpuLimit = source["cpuLimit"];
+	        this.memRequest = source["memRequest"];
+	        this.memLimit = source["memLimit"];
+	    }
+	}
 	export class ContainerEnvFrom {
 	    source: string;
 	    prefix: string;
@@ -1940,6 +1958,8 @@ export namespace kube {
 	    ports: ContainerPort[];
 	    env: ContainerEnvVar[];
 	    envFrom: ContainerEnvFrom[];
+	    resources: ContainerResources;
+	    allocated: ContainerResources;
 	
 	    static createFrom(source: any = {}) {
 	        return new ContainerDetail(source);
@@ -1958,6 +1978,8 @@ export namespace kube {
 	        this.ports = this.convertValues(source["ports"], ContainerPort);
 	        this.env = this.convertValues(source["env"], ContainerEnvVar);
 	        this.envFrom = this.convertValues(source["envFrom"], ContainerEnvFrom);
+	        this.resources = this.convertValues(source["resources"], ContainerResources);
+	        this.allocated = this.convertValues(source["allocated"], ContainerResources);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -1978,6 +2000,7 @@ export namespace kube {
 		    return a;
 		}
 	}
+	
 	
 	
 	
@@ -5730,6 +5753,7 @@ export namespace kube {
 	    initContainers: ContainerDetail[];
 	    containers: ContainerDetail[];
 	    conditions: ConditionDetail[];
+	    resizeStatus: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new PodDetail(source);
@@ -5756,6 +5780,7 @@ export namespace kube {
 	        this.initContainers = this.convertValues(source["initContainers"], ContainerDetail);
 	        this.containers = this.convertValues(source["containers"], ContainerDetail);
 	        this.conditions = this.convertValues(source["conditions"], ConditionDetail);
+	        this.resizeStatus = source["resizeStatus"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/kube/informers_pods.go
+++ b/internal/kube/informers_pods.go
@@ -55,6 +55,37 @@ type ContainerDetail struct {
 	Ports        []ContainerPort    `json:"ports"`
 	Env          []ContainerEnvVar  `json:"env"`
 	EnvFrom      []ContainerEnvFrom `json:"envFrom"`
+	// Resources is what the spec asks for; Allocated is what the kubelet has
+	// actually granted (status.containerStatuses[].resources). They diverge
+	// while an in-place resize is still being applied or was Deferred.
+	Resources ContainerResources `json:"resources"`
+	Allocated ContainerResources `json:"allocated"`
+}
+
+type ContainerResources struct {
+	CPURequest string `json:"cpuRequest"`
+	CPULimit   string `json:"cpuLimit"`
+	MemRequest string `json:"memRequest"`
+	MemLimit   string `json:"memLimit"`
+}
+
+func containerResources(rr corev1.ResourceRequirements) ContainerResources {
+	return resourcesFrom(rr.Requests, rr.Limits)
+}
+
+func resourcesFrom(requests, limits corev1.ResourceList) ContainerResources {
+	q := func(list corev1.ResourceList, name corev1.ResourceName) string {
+		if v, ok := list[name]; ok {
+			return v.String()
+		}
+		return ""
+	}
+	return ContainerResources{
+		CPURequest: q(requests, corev1.ResourceCPU),
+		CPULimit:   q(limits, corev1.ResourceCPU),
+		MemRequest: q(requests, corev1.ResourceMemory),
+		MemLimit:   q(limits, corev1.ResourceMemory),
+	}
 }
 
 type ContainerPort struct {
@@ -102,6 +133,11 @@ type PodDetail struct {
 	InitContainers    []ContainerDetail `json:"initContainers"`
 	Containers        []ContainerDetail `json:"containers"`
 	Conditions        []ConditionDetail `json:"conditions"`
+	// ResizeStatus reflects an in-flight in-place resize: "Proposed",
+	// "InProgress", "Deferred" or "Infeasible" (empty when none is pending).
+	// Read from .status.resize on older clusters and from the
+	// PodResizePending / PodResizeInProgress conditions on 1.33+.
+	ResizeStatus string `json:"resizeStatus"`
 }
 
 func (w *contextWatcher) Pod(namespace, name string) (*PodDetail, error) {
@@ -142,7 +178,32 @@ func (w *contextWatcher) Pod(namespace, name string) (*PodDetail, error) {
 		InitContainers:    w.containerDetails(p, p.Spec.InitContainers, p.Status.InitContainerStatuses),
 		Containers:        w.containerDetails(p, p.Spec.Containers, p.Status.ContainerStatuses),
 		Conditions:        podConditions(p.Status.Conditions),
+		ResizeStatus:      podResizeStatus(p),
 	}, nil
+}
+
+// podResizeStatus surfaces an in-flight in-place resize. Kubernetes ≤1.32
+// exposed it as the .status.resize enum; 1.33 moved it to the
+// PodResizePending / PodResizeInProgress conditions, so both are checked.
+func podResizeStatus(p *corev1.Pod) string {
+	if s := string(p.Status.Resize); s != "" {
+		return s
+	}
+	for _, c := range p.Status.Conditions {
+		if c.Status != corev1.ConditionTrue {
+			continue
+		}
+		switch c.Type {
+		case "PodResizeInProgress":
+			return "InProgress"
+		case "PodResizePending":
+			if c.Reason != "" {
+				return c.Reason // "Deferred" or "Infeasible"
+			}
+			return "Pending"
+		}
+	}
+	return ""
 }
 
 // replicaSetController resolves the controller that owns the named ReplicaSet
@@ -182,15 +243,19 @@ func (w *contextWatcher) containerDetails(pod *corev1.Pod, specs []corev1.Contai
 			})
 		}
 		d := ContainerDetail{
-			Name:    c.Name,
-			Image:   c.Image,
-			Ports:   ports,
-			Env:     w.envVarsFrom(pod, c, c.Env),
-			EnvFrom: envFromSources(c.EnvFrom),
+			Name:      c.Name,
+			Image:     c.Image,
+			Ports:     ports,
+			Env:       w.envVarsFrom(pod, c, c.Env),
+			EnvFrom:   envFromSources(c.EnvFrom),
+			Resources: containerResources(c.Resources),
 		}
 		if s, ok := byName[c.Name]; ok {
 			d.Ready = s.Ready
 			d.RestartCount = s.RestartCount
+			if s.Resources != nil {
+				d.Allocated = resourcesFrom(s.Resources.Requests, s.Resources.Limits)
+			}
 			switch {
 			case s.State.Running != nil:
 				d.State = "Running"

--- a/internal/kube/mutate.go
+++ b/internal/kube/mutate.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -425,6 +426,85 @@ func (m *ClientManager) PatchHPAReplicas(ctx context.Context, contextName, names
 		metav1.PatchOptions{FieldManager: "klustr"},
 	)
 	return err
+}
+
+// ResizePodResources changes a running container's CPU/memory requests and
+// limits in place via the pods/resize subresource (KEP-1287, beta and on by
+// default since Kubernetes 1.33), so the pod keeps running instead of being
+// recreated. Each field is optional; an empty string leaves that quantity
+// untouched. Non-empty values are validated as resource.Quantity before any
+// request is issued. Whether a container actually restarts is governed by its
+// resizePolicy, not by Klustr.
+func (m *ClientManager) ResizePodResources(ctx context.Context, contextName, namespace, podName, container, cpuRequest, cpuLimit, memRequest, memLimit string) error {
+	if err := m.assertWritable(contextName); err != nil {
+		return err
+	}
+	data, err := buildResizePatch(container, cpuRequest, cpuLimit, memRequest, memLimit)
+	if err != nil {
+		return err
+	}
+
+	cs, err := m.Clientset(contextName)
+	if err != nil {
+		return err
+	}
+	_, err = cs.CoreV1().Pods(namespace).Patch(
+		ctx, podName, types.StrategicMergePatchType, data,
+		metav1.PatchOptions{FieldManager: "klustr"}, "resize",
+	)
+	return err
+}
+
+// buildResizePatch validates the quantities and builds the strategic-merge
+// patch body sent to the pods/resize subresource. An empty field is omitted so
+// it stays untouched; at least one request or limit must be set.
+func buildResizePatch(container, cpuRequest, cpuLimit, memRequest, memLimit string) ([]byte, error) {
+	if container == "" {
+		return nil, fmt.Errorf("container name is required")
+	}
+	requests := map[string]string{}
+	limits := map[string]string{}
+	add := func(dst map[string]string, key, raw string) error {
+		if raw == "" {
+			return nil
+		}
+		if _, err := apiresource.ParseQuantity(raw); err != nil {
+			return fmt.Errorf("invalid quantity %q: %w", raw, err)
+		}
+		dst[key] = raw
+		return nil
+	}
+	if err := add(requests, "cpu", cpuRequest); err != nil {
+		return nil, err
+	}
+	if err := add(requests, "memory", memRequest); err != nil {
+		return nil, err
+	}
+	if err := add(limits, "cpu", cpuLimit); err != nil {
+		return nil, err
+	}
+	if err := add(limits, "memory", memLimit); err != nil {
+		return nil, err
+	}
+	if len(requests) == 0 && len(limits) == 0 {
+		return nil, fmt.Errorf("nothing to resize: set at least one request or limit")
+	}
+
+	resources := map[string]any{}
+	if len(requests) > 0 {
+		resources["requests"] = requests
+	}
+	if len(limits) > 0 {
+		resources["limits"] = limits
+	}
+	patch := map[string]any{
+		"spec": map[string]any{
+			"containers": []any{
+				map[string]any{"name": container, "resources": resources},
+			},
+		},
+	}
+	return json.Marshal(patch)
 }
 
 func (m *ClientManager) ScaleResource(ctx context.Context, contextName, kind, namespace, name string, replicas int32) error {

--- a/internal/kube/mutate_test.go
+++ b/internal/kube/mutate_test.go
@@ -1,10 +1,69 @@
 package kube
 
 import (
+	"encoding/json"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+func TestBuildResizePatch(t *testing.T) {
+	if _, err := buildResizePatch("", "100m", "", "", ""); err == nil {
+		t.Fatal("empty container name should error")
+	}
+	if _, err := buildResizePatch("app", "", "", "", ""); err == nil {
+		t.Fatal("no quantities should error")
+	}
+	if _, err := buildResizePatch("app", "not-a-qty", "", "", ""); err == nil {
+		t.Fatal("invalid quantity should error")
+	}
+
+	data, err := buildResizePatch("app", "250m", "500m", "128Mi", "256Mi")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got struct {
+		Spec struct {
+			Containers []struct {
+				Name      string `json:"name"`
+				Resources struct {
+					Requests map[string]string `json:"requests"`
+					Limits   map[string]string `json:"limits"`
+				} `json:"resources"`
+			} `json:"containers"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("patch is not valid JSON: %v", err)
+	}
+	c := got.Spec.Containers[0]
+	if c.Name != "app" {
+		t.Fatalf("container name = %q, want app", c.Name)
+	}
+	if c.Resources.Requests["cpu"] != "250m" || c.Resources.Requests["memory"] != "128Mi" {
+		t.Fatalf("requests = %v", c.Resources.Requests)
+	}
+	if c.Resources.Limits["cpu"] != "500m" || c.Resources.Limits["memory"] != "256Mi" {
+		t.Fatalf("limits = %v", c.Resources.Limits)
+	}
+
+	// A partial resize must omit the untouched side entirely.
+	data, err = buildResizePatch("app", "", "", "512Mi", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var partial map[string]any
+	if err := json.Unmarshal(data, &partial); err != nil {
+		t.Fatalf("patch is not valid JSON: %v", err)
+	}
+	res := partial["spec"].(map[string]any)["containers"].([]any)[0].(map[string]any)["resources"].(map[string]any)
+	if _, hasLimits := res["limits"]; hasLimits {
+		t.Fatalf("limits should be omitted, got %v", res["limits"])
+	}
+	if res["requests"].(map[string]any)["memory"] != "512Mi" {
+		t.Fatalf("expected memory request 512Mi, got %v", res["requests"])
+	}
+}
 
 func TestResourceForKind(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## What

Change a running container's CPU/memory requests and limits **without recreating the pod**, via the `pods/resize` subresource (KEP-1287, beta and on by default since Kubernetes 1.33). This is the Freelens 1.9.0 headline feature; no GUI competitor on the free tier ships it.

- **Resize action** on the pod detail header (left of port-forward, hidden in read-only mode). The dialog loads the current per-container requests/limits, lets you edit any subset (blank = unchanged), and applies in place. Multi-container pods get a container picker.
- **Resource visibility** — the Overview containers table now shows CPU and memory `req/lim` columns, and a banner surfaces an in-flight resize (`Deferred` → no room yet, retrying; `Infeasible` → node can't satisfy it).
- Quantities are validated as `resource.Quantity` before any request; the QoS-class and node-capacity constraints are explained in the dialog.

## How it's built

- `internal/kube/mutate.go` — `ResizePodResources` patches the `pods/resize` subresource with a strategic-merge patch; the patch-building/validation core is factored into `buildResizePatch` and unit-tested (`mutate_test.go`).
- `internal/kube/informers_pods.go` — `ContainerDetail` gains spec + allocated resources; `PodDetail` gains `resizeStatus` (read from `.status.resize` on ≤1.32 and the `PodResizePending`/`PodResizeInProgress` conditions on 1.33+).
- `app/app.go` + generated bindings; `frontend/src/features/pods/ResizePodButton.tsx`.

## Testing

- `go test klustr/internal/...` + `go vet ./...` pass (`TestBuildResizePatch` covers validation, partial patches, and patch shape).
- Frontend `npm test` / `lint` / `typecheck` pass.
- Verified live in `wails dev` against a 1.35 cluster: resized a running container's memory limit in place, pod kept running, the new allocation and columns updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)