### PR TITLE
chore(deps): bump dompurify override to ^3.4.9

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3768,9 +3768,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,6 @@
     "vitest": "^4.1.8"
   },
   "overrides": {
-    "dompurify": "^3.4.0"
+    "dompurify": "^3.4.9"
   }
 }


### PR DESCRIPTION
## What

Raise the `dompurify` resolution override in `frontend/package.json` from `^3.4.0` to `^3.4.9` (resolves to **3.4.10**).

## Why

`monaco-editor` bundles a vulnerable `dompurify` 3.2.7. The existing `^3.4.0` override forced it up to 3.4.5, but 3.4.5 is still below the lowest non-vulnerable version (3.4.9), so seven open DOMPurify advisories remained. Dependabot's security-update jobs could not auto-fix these — the resolver path would have downgraded `monaco-editor` 0.55.1 → 0.53.0 — so bumping the override directly is the clean fix.

Practical exposure was low (we never call DOMPurify ourselves; monaco uses it with default config to sanitize static hover markdown inside the desktop webview), but this clears the alerts with no functional change.

## Verification

- `npm audit` — all dompurify advisories gone; only the dev-only `@babel/core` (low) alert remains
- `npm run typecheck` — clean
- `npm test` — 127/127 pass
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run build` — succeeds