### PR TITLE
feat(pods): filter pods by status from the Status column header

### DIFF
--- a/frontend/src/features/_shared/ResourceTable.tsx
+++ b/frontend/src/features/_shared/ResourceTable.tsx
@@ -1141,7 +1141,7 @@ export function ResourceTable<T>({
                                 <Filter className="size-3.5" />
                               </button>
                             </DropdownMenuTrigger>
-                            <DropdownMenuContent align="start" className="max-h-80 overflow-y-auto">
+                            <DropdownMenuContent align="start" className="w-auto">
                               <DropdownMenuRadioGroup
                                 value={headerFilter.value}
                                 onValueChange={headerFilter.onChange}

--- a/frontend/src/features/_shared/ResourceTable.tsx
+++ b/frontend/src/features/_shared/ResourceTable.tsx
@@ -20,6 +20,7 @@ import {
   ChevronRight,
   ChevronsUpDown,
   CircleCheck,
+  Filter,
   MoveDownLeft,
   RotateCcw,
   Search,
@@ -110,6 +111,8 @@ export type ResourceTableProps<T> = {
   // refetching the whole list. Falls back to a full refetch on reset/gap and on
   // the initial load, which stays the source of truth.
   applyDelta?: (contextName: string, upserts: T[], removed: string[]) => void
+  // Exact-match filters rendered as a funnel icon in the column header.
+  headerFilters?: HeaderFilter<T>[]
 }
 
 function identityKey(ctx: string, r: RowIdentity): string {
@@ -150,6 +153,14 @@ function mergeOrder(all: string[], saved: string[]): string[] {
     if (!seen.has(id)) result.push(id)
   }
   return result
+}
+
+export type HeaderFilter<T> = {
+  columnId: string
+  options: string[]
+  value: string
+  onChange: (value: string) => void
+  accessor: (row: T) => string
 }
 
 type ResourceRowProps<T> = {
@@ -282,6 +293,7 @@ export function ResourceTable<T>({
   onRowClick,
   rowResource,
   applyDelta,
+  headerFilters,
 }: ResourceTableProps<T>) {
   const activeContexts = useActiveContexts()
   const resourceContexts = resolveResourceContexts(activeContexts, contexts)
@@ -316,6 +328,11 @@ export function ResourceTable<T>({
     const id = window.setTimeout(() => setAppliedFilter(filter), 180)
     return () => window.clearTimeout(id)
   }, [filter])
+  // Read via ref + content key so an inline headerFilters literal in the
+  // calling view doesn't re-filter on every render.
+  const headerFiltersRef = useRef(headerFilters)
+  headerFiltersRef.current = headerFilters
+  const headerFilterKey = (headerFilters ?? []).map((f) => f.value).join('\u0000')
   const prefs = useTablePrefs((s) => s.byKind[kind])
   const persistedSizing = useMemo<ColumnSizingState>(
     () => prefs?.sizing ?? EMPTY_SIZING,
@@ -400,7 +417,7 @@ export function ResourceTable<T>({
   }, [resourceContexts, selectedNamespaces, kind])
   useEffect(() => {
     setPageIndex(0)
-  }, [resourceContexts, selectedNamespaces, kind, appliedFilter, pageSize])
+  }, [resourceContexts, selectedNamespaces, kind, appliedFilter, headerFilterKey, pageSize])
   const filterRef = useRef<HTMLInputElement>(null)
   const [flashKey, setFlashKey] = useState<string | null>(null)
   const [loadedSet, setLoadedSet] = useState<Set<string>>(() => new Set())
@@ -618,14 +635,22 @@ export function ResourceTable<T>({
     }
     return m
   }, [tableColumns])
+  const filteredData = useMemo(() => {
+    const active = (headerFiltersRef.current ?? []).filter((f) => f.value)
+    if (active.length === 0) return mergedData
+    return mergedData.filter((row) =>
+      active.every((f) => f.accessor(row as unknown as T) === f.value),
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- headerFilterKey is the content key for headerFilters
+  }, [mergedData, headerFilterKey])
   const searchedData = useMemo(() => {
     const terms = parseSearch(appliedFilter)
-    if (terms.length === 0) return mergedData
+    if (terms.length === 0) return filteredData
     const ids = [...columnGetters.keys()]
-    return mergedData.filter((row) =>
+    return filteredData.filter((row) =>
       rowMatchesSearch(row, terms, ids, (r, id) => columnGetters.get(id)?.(r as Tagged<T>)),
     )
-  }, [mergedData, appliedFilter, columnGetters])
+  }, [filteredData, appliedFilter, columnGetters])
   const columnOrder = useMemo(() => {
     const saved = prefs?.order ?? []
     if (!isAggregated || saved.includes('klustrContext')) {
@@ -813,7 +838,7 @@ export function ResourceTable<T>({
   const total = mergedData.length
   const countLabel = !allLoaded
     ? `Loading ${noun.plural}…`
-    : appliedFilter
+    : appliedFilter || headerFilterKey
       ? `${filteredCount} of ${total} ${total === 1 ? noun.singular : noun.plural}`
       : `${total} ${total === 1 ? noun.singular : noun.plural}`
   const scopeLabel =
@@ -1007,6 +1032,7 @@ export function ResourceTable<T>({
                   const sorted = h.column.getIsSorted()
                   const canSort = h.column.getCanSort()
                   const colId = h.column.id
+                  const headerFilter = headerFilters?.find((f) => f.columnId === colId)
                   const isDragging = dragColId === colId
                   const isDropTarget =
                     dragColId !== null && dropTargetColId === colId && dragColId !== colId
@@ -1084,17 +1110,53 @@ export function ResourceTable<T>({
                           : '',
                       ].join(' ')}
                     >
-                      {canSort ? (
-                        <button
-                          type="button"
-                          className="flex w-full min-w-0 cursor-pointer items-center gap-1 rounded-sm text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                          onClick={h.column.getToggleSortingHandler()}
-                        >
-                          {headerContent}
-                        </button>
-                      ) : (
-                        <span className="flex min-w-0 items-center gap-1">{headerContent}</span>
-                      )}
+                      <span className="flex w-full min-w-0 items-center gap-1">
+                        {canSort ? (
+                          <button
+                            type="button"
+                            className="flex min-w-0 flex-1 cursor-pointer items-center gap-1 rounded-sm text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                            onClick={h.column.getToggleSortingHandler()}
+                          >
+                            {headerContent}
+                          </button>
+                        ) : (
+                          <span className="flex min-w-0 flex-1 items-center gap-1">
+                            {headerContent}
+                          </span>
+                        )}
+                        {headerFilter && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                type="button"
+                                aria-label={`Filter by ${String(h.column.columnDef.header ?? colId)}`}
+                                onClick={(e) => e.stopPropagation()}
+                                className={[
+                                  '-my-1 -mr-1 shrink-0 rounded p-1.5 hover:bg-muted hover:text-foreground',
+                                  headerFilter.value
+                                    ? 'text-primary'
+                                    : 'text-muted-foreground opacity-0 focus-visible:opacity-100 group-hover:opacity-100',
+                                ].join(' ')}
+                              >
+                                <Filter className="size-3.5" />
+                              </button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="start" className="max-h-80 overflow-y-auto">
+                              <DropdownMenuRadioGroup
+                                value={headerFilter.value}
+                                onValueChange={headerFilter.onChange}
+                              >
+                                <DropdownMenuRadioItem value="">All</DropdownMenuRadioItem>
+                                {headerFilter.options.map((opt) => (
+                                  <DropdownMenuRadioItem key={opt} value={opt}>
+                                    {opt}
+                                  </DropdownMenuRadioItem>
+                                ))}
+                              </DropdownMenuRadioGroup>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
+                      </span>
                       <span
                         draggable={false}
                         onMouseDown={startResize(h.column.id)}

--- a/frontend/src/features/_shared/ResourceTable.tsx
+++ b/frontend/src/features/_shared/ResourceTable.tsx
@@ -61,6 +61,7 @@ import {
   type BulkItem,
 } from './BulkActionDialogs'
 import { isRestartable } from './workloadCapabilities'
+import { applyHeaderFilters, headerFilterOptions } from './headerFilter'
 import { parseSearch, rowMatchesSearch } from './rowSearch'
 import { KLUSTR_CTX, resolveResourceContexts, type Tagged } from './resourceContext'
 import { resourcePageCount } from './pagination'
@@ -111,8 +112,10 @@ export type ResourceTableProps<T> = {
   // refetching the whole list. Falls back to a full refetch on reset/gap and on
   // the initial load, which stays the source of truth.
   applyDelta?: (contextName: string, upserts: T[], removed: string[]) => void
-  // Exact-match filters rendered as a funnel icon in the column header.
-  headerFilters?: HeaderFilter<T>[]
+  // Column ids that get a funnel icon in their header for exact-match
+  // filtering. Options and selection are owned by the table; pass a
+  // module-level constant so the array identity stays stable.
+  headerFilters?: string[]
 }
 
 function identityKey(ctx: string, r: RowIdentity): string {
@@ -153,14 +156,6 @@ function mergeOrder(all: string[], saved: string[]): string[] {
     if (!seen.has(id)) result.push(id)
   }
   return result
-}
-
-export type HeaderFilter<T> = {
-  columnId: string
-  options: string[]
-  value: string
-  onChange: (value: string) => void
-  accessor: (row: T) => string
 }
 
 type ResourceRowProps<T> = {
@@ -328,11 +323,8 @@ export function ResourceTable<T>({
     const id = window.setTimeout(() => setAppliedFilter(filter), 180)
     return () => window.clearTimeout(id)
   }, [filter])
-  // Read via ref + content key so an inline headerFilters literal in the
-  // calling view doesn't re-filter on every render.
-  const headerFiltersRef = useRef(headerFilters)
-  headerFiltersRef.current = headerFilters
-  const headerFilterKey = (headerFilters ?? []).map((f) => f.value).join('\u0000')
+  const [headerFilterValues, setHeaderFilterValues] = useState<Record<string, string>>({})
+  const hasHeaderFilter = Object.values(headerFilterValues).some(Boolean)
   const prefs = useTablePrefs((s) => s.byKind[kind])
   const persistedSizing = useMemo<ColumnSizingState>(
     () => prefs?.sizing ?? EMPTY_SIZING,
@@ -417,7 +409,7 @@ export function ResourceTable<T>({
   }, [resourceContexts, selectedNamespaces, kind])
   useEffect(() => {
     setPageIndex(0)
-  }, [resourceContexts, selectedNamespaces, kind, appliedFilter, headerFilterKey, pageSize])
+  }, [resourceContexts, selectedNamespaces, kind, appliedFilter, headerFilterValues, pageSize])
   const filterRef = useRef<HTMLInputElement>(null)
   const [flashKey, setFlashKey] = useState<string | null>(null)
   const [loadedSet, setLoadedSet] = useState<Set<string>>(() => new Set())
@@ -635,14 +627,22 @@ export function ResourceTable<T>({
     }
     return m
   }, [tableColumns])
-  const filteredData = useMemo(() => {
-    const active = (headerFiltersRef.current ?? []).filter((f) => f.value)
-    if (active.length === 0) return mergedData
-    return mergedData.filter((row) =>
-      active.every((f) => f.accessor(row as unknown as T) === f.value),
-    )
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- headerFilterKey is the content key for headerFilters
-  }, [mergedData, headerFilterKey])
+  const filteredData = useMemo(
+    () =>
+      applyHeaderFilters(mergedData, headerFilterValues, (row, id) =>
+        columnGetters.get(id.toLowerCase())?.(row),
+      ),
+    [mergedData, headerFilterValues, columnGetters],
+  )
+  const headerFilterOpts = useMemo(() => {
+    const m = new Map<string, string[]>()
+    for (const id of headerFilters ?? []) {
+      const get = columnGetters.get(id.toLowerCase())
+      if (!get) continue
+      m.set(id, headerFilterOptions(mergedData, get, headerFilterValues[id] ?? ''))
+    }
+    return m
+  }, [headerFilters, columnGetters, mergedData, headerFilterValues])
   const searchedData = useMemo(() => {
     const terms = parseSearch(appliedFilter)
     if (terms.length === 0) return filteredData
@@ -838,7 +838,7 @@ export function ResourceTable<T>({
   const total = mergedData.length
   const countLabel = !allLoaded
     ? `Loading ${noun.plural}…`
-    : appliedFilter || headerFilterKey
+    : appliedFilter || hasHeaderFilter
       ? `${filteredCount} of ${total} ${total === 1 ? noun.singular : noun.plural}`
       : `${total} ${total === 1 ? noun.singular : noun.plural}`
   const scopeLabel =
@@ -1032,7 +1032,8 @@ export function ResourceTable<T>({
                   const sorted = h.column.getIsSorted()
                   const canSort = h.column.getCanSort()
                   const colId = h.column.id
-                  const headerFilter = headerFilters?.find((f) => f.columnId === colId)
+                  const filterOptions = headerFilterOpts.get(colId)
+                  const filterValue = headerFilterValues[colId] ?? ''
                   const isDragging = dragColId === colId
                   const isDropTarget =
                     dragColId !== null && dropTargetColId === colId && dragColId !== colId
@@ -1124,16 +1125,15 @@ export function ResourceTable<T>({
                             {headerContent}
                           </span>
                         )}
-                        {headerFilter && (
+                        {filterOptions && (
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <button
                                 type="button"
-                                aria-label={`Filter by ${String(h.column.columnDef.header ?? colId)}`}
-                                onClick={(e) => e.stopPropagation()}
+                                aria-label={`Filter by ${typeof h.column.columnDef.header === 'string' ? h.column.columnDef.header : colId}`}
                                 className={[
                                   '-my-1 -mr-1 shrink-0 rounded p-1.5 hover:bg-muted hover:text-foreground',
-                                  headerFilter.value
+                                  filterValue
                                     ? 'text-primary'
                                     : 'text-muted-foreground opacity-0 focus-visible:opacity-100 group-hover:opacity-100',
                                 ].join(' ')}
@@ -1143,11 +1143,13 @@ export function ResourceTable<T>({
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="start" className="w-auto">
                               <DropdownMenuRadioGroup
-                                value={headerFilter.value}
-                                onValueChange={headerFilter.onChange}
+                                value={filterValue}
+                                onValueChange={(v) =>
+                                  setHeaderFilterValues((prev) => ({ ...prev, [colId]: v }))
+                                }
                               >
                                 <DropdownMenuRadioItem value="">All</DropdownMenuRadioItem>
-                                {headerFilter.options.map((opt) => (
+                                {filterOptions.map((opt) => (
                                   <DropdownMenuRadioItem key={opt} value={opt}>
                                     {opt}
                                   </DropdownMenuRadioItem>

--- a/frontend/src/features/_shared/headerFilter.test.ts
+++ b/frontend/src/features/_shared/headerFilter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { applyHeaderFilters, headerFilterOptions } from './headerFilter'
+
+type Row = { status: string; node: string }
+
+const rows: Row[] = [
+  { status: 'Running', node: 'a' },
+  { status: 'CrashLoopBackOff', node: 'b' },
+  { status: 'Running', node: 'a' },
+  { status: 'Completed', node: 'c' },
+]
+
+describe('headerFilterOptions', () => {
+  it('returns sorted unique values', () => {
+    expect(headerFilterOptions(rows, (r) => r.status, '')).toEqual([
+      'Completed',
+      'CrashLoopBackOff',
+      'Running',
+    ])
+  })
+
+  it('skips empty and non-string values', () => {
+    const mixed = [{ v: '' }, { v: 'x' }, { v: null }, { v: 3 }]
+    expect(headerFilterOptions(mixed, (r) => r.v, '')).toEqual(['x'])
+  })
+
+  it('keeps an active value that no longer occurs in the data', () => {
+    expect(headerFilterOptions(rows, (r) => r.status, 'Evicted')).toContain('Evicted')
+  })
+})
+
+describe('applyHeaderFilters', () => {
+  const get = (row: Row, id: string) => row[id as keyof Row]
+
+  it('returns the input untouched when nothing is active', () => {
+    expect(applyHeaderFilters(rows, {}, get)).toBe(rows)
+    expect(applyHeaderFilters(rows, { status: '' }, get)).toBe(rows)
+  })
+
+  it('matches exactly, not by substring', () => {
+    expect(applyHeaderFilters(rows, { status: 'Running' }, get)).toHaveLength(2)
+    expect(applyHeaderFilters(rows, { status: 'Run' }, get)).toHaveLength(0)
+  })
+
+  it('ANDs multiple active columns', () => {
+    expect(applyHeaderFilters(rows, { status: 'Running', node: 'a' }, get)).toHaveLength(2)
+    expect(applyHeaderFilters(rows, { status: 'Running', node: 'c' }, get)).toHaveLength(0)
+  })
+})

--- a/frontend/src/features/_shared/headerFilter.ts
+++ b/frontend/src/features/_shared/headerFilter.ts
@@ -1,0 +1,30 @@
+// Exact-match column filters, offered as a dropdown in the column header.
+// Options are derived from the rows themselves, so the menu can only offer
+// values that are actually on screen.
+
+export function headerFilterOptions<R>(
+  rows: R[],
+  get: (row: R) => unknown,
+  active: string,
+): string[] {
+  const seen = new Set<string>()
+  for (const row of rows) {
+    const v = get(row)
+    if (typeof v === 'string' && v) seen.add(v)
+  }
+  // A filter whose value has disappeared from the data still belongs in the
+  // menu — otherwise the table is empty and nothing in the open dropdown shows
+  // why.
+  if (active) seen.add(active)
+  return [...seen].sort((a, b) => a.localeCompare(b))
+}
+
+export function applyHeaderFilters<R>(
+  rows: R[],
+  values: Record<string, string>,
+  get: (row: R, columnId: string) => unknown,
+): R[] {
+  const active = Object.entries(values).filter(([, v]) => v)
+  if (active.length === 0) return rows
+  return rows.filter((row) => active.every(([id, v]) => get(row, id) === v))
+}

--- a/frontend/src/features/pods/PodsView.tsx
+++ b/frontend/src/features/pods/PodsView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { createColumnHelper } from '@tanstack/react-table'
 import { api, type PodInfo } from '@/lib/api'
 import { formatAge } from '@/lib/time'
@@ -71,8 +71,9 @@ function statusClass(status: string): string {
   return 'text-foreground'
 }
 
+const HEADER_FILTERS = ['status']
+
 export function PodsView() {
-  const [statusFilter, setStatusFilter] = useState('')
   const pods = useResources((s) => s.pods)
   const setPods = useResources((s) => s.setPods)
   const applyPodsDelta = useResources((s) => s.applyPodsDelta)
@@ -81,14 +82,6 @@ export function PodsView() {
   const selectedNamespaces = useUIStore((s) => s.selectedNamespaces)
   const metricsAvailable = useMetrics(selectMetricsAvailable(activeContexts))
   usePodMetricsPoll(activeContexts, namespaceQuery(selectedNamespaces).apiNamespace)
-
-  const statusOptions = useMemo(() => {
-    const statuses = new Set<string>()
-    for (const list of Object.values(pods)) {
-      for (const pod of list) statuses.add(pod.status)
-    }
-    return [...statuses].sort((a, b) => a.localeCompare(b))
-  }, [pods])
 
   const columns = useMemo(
     () => [
@@ -157,15 +150,7 @@ export function PodsView() {
       applyDelta={applyPodsDelta}
       fetch={api.listPods}
       columns={columns}
-      headerFilters={[
-        {
-          columnId: 'status',
-          options: statusOptions,
-          value: statusFilter,
-          onChange: setStatusFilter,
-          accessor: (pod) => pod.status,
-        },
-      ]}
+      headerFilters={HEADER_FILTERS}
       onRowClick={(row, ctx) =>
         setSelectedResource({ kind: 'Pod', namespace: row.namespace, name: row.name, context: ctx })
       }

--- a/frontend/src/features/pods/PodsView.tsx
+++ b/frontend/src/features/pods/PodsView.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { createColumnHelper } from '@tanstack/react-table'
 import { api, type PodInfo } from '@/lib/api'
 import { formatAge } from '@/lib/time'
@@ -72,6 +72,7 @@ function statusClass(status: string): string {
 }
 
 export function PodsView() {
+  const [statusFilter, setStatusFilter] = useState('')
   const pods = useResources((s) => s.pods)
   const setPods = useResources((s) => s.setPods)
   const applyPodsDelta = useResources((s) => s.applyPodsDelta)
@@ -80,6 +81,14 @@ export function PodsView() {
   const selectedNamespaces = useUIStore((s) => s.selectedNamespaces)
   const metricsAvailable = useMetrics(selectMetricsAvailable(activeContexts))
   usePodMetricsPoll(activeContexts, namespaceQuery(selectedNamespaces).apiNamespace)
+
+  const statusOptions = useMemo(() => {
+    const statuses = new Set<string>()
+    for (const list of Object.values(pods)) {
+      for (const pod of list) statuses.add(pod.status)
+    }
+    return [...statuses].sort((a, b) => a.localeCompare(b))
+  }, [pods])
 
   const columns = useMemo(
     () => [
@@ -148,6 +157,15 @@ export function PodsView() {
       applyDelta={applyPodsDelta}
       fetch={api.listPods}
       columns={columns}
+      headerFilters={[
+        {
+          columnId: 'status',
+          options: statusOptions,
+          value: statusFilter,
+          onChange: setStatusFilter,
+          accessor: (pod) => pod.status,
+        },
+      ]}
       onRowClick={(row, ctx) =>
         setSelectedResource({ kind: 'Pod', namespace: row.namespace, name: row.name, context: ctx })
       }


### PR DESCRIPTION
## What

Pods can now be filtered by status. A funnel icon appears on the **Status** column header; clicking it opens a dropdown of every status present in the current pod list (plus **All**) and filters the table to the exact match.

## Why

The Status column was sortable but not filterable — finding all `CrashLoopBackOff` pods in a busy cluster meant scrolling or free-text searching. A column-level filter is where users expect it.

## How

- **`ResourceTable.tsx`**: new generic `headerFilters` prop (`{ columnId, options, value, onChange, accessor }[]`). Each entry renders a funnel button in the matching column header and applies an exact-match filter client-side, before the text search and pagination. Works in single- and aggregated multi-context modes; resets pagination and updates the "X of Y pods" count label when active. The icon stays hidden until header hover, but is always visible (primary color) while a filter is applied.
- **`PodsView.tsx`**: wires one header filter on the `status` column; options are derived from the live pod data, so the list always matches what's on screen.

Filtering is frontend-only by design: the informer cache already holds the full pod list, and derived statuses like `CrashLoopBackOff` aren't API-visible field selectors anyway.

## Verification

- `npm test` (174 tests), `npm run lint`, `npm run typecheck`, `npm run build` — all pass
- Manual: `go run -tags production,webkit2_41 .` against a live cluster; filter composes with text search and namespace selection, count label and pagination react correctly
