### PR TITLE
fix(terminal): restore copy and paste on Linux and Windows

### DIFF
--- a/docs/guide/terminal.md
+++ b/docs/guide/terminal.md
@@ -31,6 +31,21 @@ Windows is not supported yet.
   Closing the last tab closes the drawer.
 - Disconnecting a context closes every terminal bound to it.
 
+## Copy and paste
+
+The same bindings apply to every terminal surface — this drawer, **Exec**,
+**Node shell** and the **Logs** viewers (copy only there):
+
+| | macOS | Linux / Windows |
+|---|---|---|
+| Copy selection | `⌘C` | `Ctrl+Shift+C` or `Ctrl+Insert` |
+| Paste | `⌘V` | `Ctrl+Shift+V` or `Shift+Insert` |
+
+On Linux and Windows a plain `Ctrl+C` copies while text is selected and is the
+shell's interrupt otherwise — the same rule Windows Terminal and VS Code use.
+`Ctrl+V` is never intercepted; it reaches the shell as `^V`. Right-click any
+terminal for a **Copy / Paste / Select all** menu.
+
 ## Opening an external terminal app
 
 Prefer your own terminal? A tab can launch an external app (Terminal, iTerm2,

--- a/docs/guide/workloads-and-debugging.md
+++ b/docs/guide/workloads-and-debugging.md
@@ -20,6 +20,9 @@ In aggregated mode the stream spans the pods across every active context.
 
 The **Exec** tab opens an interactive shell into any container over SPDY — the same
 transport `kubectl exec` uses. Pick the container if the pod has more than one.
+Copy and paste follow the terminal conventions in
+[Terminal → Copy and paste](terminal.md#copy-and-paste): `⌘C` / `⌘V` on macOS,
+`Ctrl+Shift+C` / `Ctrl+Shift+V` or the right-click menu on Linux and Windows.
 
 ## Debug (shell-less containers)
 

--- a/frontend/src/features/_shared/KeyboardShortcutsDialog.tsx
+++ b/frontend/src/features/_shared/KeyboardShortcutsDialog.tsx
@@ -41,6 +41,9 @@ const GROUPS: Group[] = [
     shortcuts: [
       { keys: [MOD_KEY, '`'], label: 'Toggle terminal panel' },
       { keys: ['Alt', 'Click'], label: 'Show external terminal picker' },
+      { keys: IS_MAC ? [MOD_KEY, 'C'] : ['Ctrl', 'Shift', 'C'], label: 'Copy terminal selection' },
+      { keys: IS_MAC ? [MOD_KEY, 'V'] : ['Ctrl', 'Shift', 'V'], label: 'Paste into terminal' },
+      { keys: ['Right-click'], label: 'Terminal copy / paste menu' },
     ],
   },
   {

--- a/frontend/src/features/_shared/MultiPodLogsTab.tsx
+++ b/frontend/src/features/_shared/MultiPodLogsTab.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { EventsOff, EventsOn } from '@/lib/wails/wailsjs/runtime/runtime'
 import { api, type PodLogTarget } from '@/lib/api'
 import { xtermThemeFor } from '@/features/_shared/xtermTheme'
+import { installClipboardBindings } from '@/features/_shared/xtermClipboard'
 import { highlightLogContent } from '@/features/_shared/logHighlight'
 import { pushCapped } from '@/features/_shared/pushCapped'
 import { useUIStore } from '@/store/ui'
@@ -139,6 +140,7 @@ export function MultiPodLogsTab({ contextName, namespace, selector, title }: Pro
     const fit = new FitAddon()
     term.loadAddon(fit)
     term.open(termHostRef.current)
+    installClipboardBindings(term, { readOnly: true })
     fit.fit()
     termRef.current = term
     fitRef.current = fit

--- a/frontend/src/features/_shared/MultiPodLogsTab.tsx
+++ b/frontend/src/features/_shared/MultiPodLogsTab.tsx
@@ -11,6 +11,7 @@ import { xtermThemeFor } from '@/features/_shared/xtermTheme'
 import { installClipboardBindings } from '@/features/_shared/xtermClipboard'
 import { highlightLogContent } from '@/features/_shared/logHighlight'
 import { pushCapped } from '@/features/_shared/pushCapped'
+import { TerminalContextMenu } from '@/features/_shared/TerminalContextMenu'
 import { useUIStore } from '@/store/ui'
 
 const TAIL_LINES = 50
@@ -390,7 +391,9 @@ export function MultiPodLogsTab({ contextName, namespace, selector, title }: Pro
         </div>
       )}
       <div className="relative min-h-0 flex-1">
-        <div ref={termHostRef} className="absolute inset-0 bg-background px-2 py-1" />
+        <TerminalContextMenu terminal={() => termRef.current} readOnly>
+          <div ref={termHostRef} className="absolute inset-0 bg-background px-2 py-1" />
+        </TerminalContextMenu>
         {!atBottom && (
           <button
             type="button"

--- a/frontend/src/features/_shared/TerminalContextMenu.tsx
+++ b/frontend/src/features/_shared/TerminalContextMenu.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import type { Terminal } from '@xterm/xterm'
+import { ClipboardPaste, Copy, TextSelect } from 'lucide-react'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
+import { copySelection, IS_MAC, pasteClipboard } from './xtermClipboard'
+
+const COPY_HINT = IS_MAC ? '⌘C' : 'Ctrl+Shift+C'
+const PASTE_HINT = IS_MAC ? '⌘V' : 'Ctrl+Shift+V'
+
+type Props = {
+  terminal: () => Terminal | null
+  readOnly?: boolean
+  children: React.ReactNode
+}
+
+// Right-click menu for an xterm host. Wails suppresses the webview's native
+// context menu in release builds, so without this mouse-only users have no
+// paste at all on Linux/Windows.
+export function TerminalContextMenu({ terminal, readOnly, children }: Props) {
+  const [hasSelection, setHasSelection] = useState(false)
+
+  return (
+    <ContextMenu
+      onOpenChange={(open) => {
+        if (open) setHasSelection(terminal()?.hasSelection() ?? false)
+      }}
+    >
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent
+        onCloseAutoFocus={(e) => {
+          // Radix would hand focus back to the host div; the shell needs it in
+          // xterm's textarea so typing resumes right away.
+          e.preventDefault()
+          terminal()?.focus()
+        }}
+      >
+        <ContextMenuItem
+          disabled={!hasSelection}
+          onSelect={() => {
+            const term = terminal()
+            if (term) void copySelection(term)
+          }}
+        >
+          <Copy />
+          <span>Copy</span>
+          <ContextMenuShortcut>{COPY_HINT}</ContextMenuShortcut>
+        </ContextMenuItem>
+        {!readOnly && (
+          <ContextMenuItem
+            onSelect={() => {
+              const term = terminal()
+              if (term) void pasteClipboard(term)
+            }}
+          >
+            <ClipboardPaste />
+            <span>Paste</span>
+            <ContextMenuShortcut>{PASTE_HINT}</ContextMenuShortcut>
+          </ContextMenuItem>
+        )}
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={() => terminal()?.selectAll()}>
+          <TextSelect />
+          <span>Select all</span>
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/frontend/src/features/_shared/xtermClipboard.test.ts
+++ b/frontend/src/features/_shared/xtermClipboard.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { clipboardActionFor } from './xtermClipboard'
+
+type Chord = Parameters<typeof clipboardActionFor>[0]
+
+function chord(key: string, mods: Partial<Chord> = {}): Chord {
+  const code = key.length === 1 ? `Key${key.toUpperCase()}` : key
+  return { key, code, ctrlKey: false, shiftKey: false, altKey: false, metaKey: false, ...mods }
+}
+
+const linux = { isMac: false }
+
+describe('clipboardActionFor', () => {
+  it('binds the terminal-convention chords on Linux/Windows', () => {
+    expect(clipboardActionFor(chord('C', { ctrlKey: true, shiftKey: true }), { ...linux, hasSelection: false })).toBe('copy')
+    expect(clipboardActionFor(chord('V', { ctrlKey: true, shiftKey: true }), { ...linux, hasSelection: false })).toBe('paste')
+    expect(clipboardActionFor(chord('Insert', { ctrlKey: true }), { ...linux, hasSelection: false })).toBe('copy')
+    expect(clipboardActionFor(chord('Insert', { shiftKey: true }), { ...linux, hasSelection: false })).toBe('paste')
+  })
+
+  it('matches by physical key so non-QWERTY layouts still work', () => {
+    const ev = { ...chord('C', { ctrlKey: true, shiftKey: true }), key: 'Ц' }
+    expect(clipboardActionFor(ev, { ...linux, hasSelection: false })).toBe('copy')
+  })
+
+  it('turns plain Ctrl+C into copy only while text is selected', () => {
+    const ctrlC = chord('c', { ctrlKey: true })
+    expect(clipboardActionFor(ctrlC, { ...linux, hasSelection: true })).toBe('copy')
+    expect(clipboardActionFor(ctrlC, { ...linux, hasSelection: false })).toBeNull()
+  })
+
+  it('never hijacks plain Ctrl+V — that stays the ^V control byte', () => {
+    expect(clipboardActionFor(chord('v', { ctrlKey: true }), { ...linux, hasSelection: true })).toBeNull()
+  })
+
+  it('leaves Insert alone without a modifier and with both', () => {
+    expect(clipboardActionFor(chord('Insert'), { ...linux, hasSelection: true })).toBeNull()
+    expect(clipboardActionFor(chord('Insert', { ctrlKey: true, shiftKey: true }), { ...linux, hasSelection: true })).toBeNull()
+  })
+
+  it('ignores Alt and Meta chords', () => {
+    expect(clipboardActionFor(chord('C', { ctrlKey: true, shiftKey: true, altKey: true }), { ...linux, hasSelection: true })).toBeNull()
+    expect(clipboardActionFor(chord('c', { metaKey: true }), { ...linux, hasSelection: true })).toBeNull()
+  })
+
+  it('stays out of the way on macOS, where the native Edit menu already works', () => {
+    const mac = { isMac: true, hasSelection: true }
+    expect(clipboardActionFor(chord('C', { ctrlKey: true, shiftKey: true }), mac)).toBeNull()
+    expect(clipboardActionFor(chord('c', { ctrlKey: true }), mac)).toBeNull()
+    expect(clipboardActionFor(chord('Insert', { shiftKey: true }), mac)).toBeNull()
+  })
+})

--- a/frontend/src/features/_shared/xtermClipboard.ts
+++ b/frontend/src/features/_shared/xtermClipboard.ts
@@ -1,0 +1,115 @@
+import type { Terminal } from '@xterm/xterm'
+import { toast } from 'sonner'
+import { ClipboardGetText, ClipboardSetText } from '@/lib/wails/wailsjs/runtime/runtime'
+
+export type ClipboardAction = 'copy' | 'paste'
+
+type KeyChord = Pick<KeyboardEvent, 'key' | 'code' | 'ctrlKey' | 'shiftKey' | 'altKey' | 'metaKey'>
+
+export const IS_MAC =
+  typeof navigator !== 'undefined' &&
+  /(Mac|iPhone|iPad|iPod)/.test(navigator.platform || navigator.userAgent)
+
+function isLetter(ev: KeyChord, letter: 'c' | 'v'): boolean {
+  return ev.code === `Key${letter.toUpperCase()}` || ev.key.toLowerCase() === letter
+}
+
+// macOS gets copy/paste for free: Wails installs an Edit menu whose ⌘C / ⌘V
+// reach the webview as native clipboard commands, and xterm leaves ⌘-chords
+// alone. Linux and Windows have no such menu, and xterm turns Ctrl+C / Ctrl+V
+// into ^C / ^V control bytes with preventDefault, so the webview never fires a
+// clipboard event — the app has to bind the terminal-convention chords itself.
+export function clipboardActionFor(
+  ev: KeyChord,
+  opts: { hasSelection: boolean; isMac: boolean },
+): ClipboardAction | null {
+  if (opts.isMac || ev.metaKey || ev.altKey) return null
+  if (ev.ctrlKey && ev.shiftKey) {
+    if (isLetter(ev, 'c')) return 'copy'
+    if (isLetter(ev, 'v')) return 'paste'
+    return null
+  }
+  if (ev.key === 'Insert') {
+    if (ev.ctrlKey && !ev.shiftKey) return 'copy'
+    if (ev.shiftKey && !ev.ctrlKey) return 'paste'
+    return null
+  }
+  // Plain Ctrl+C copies only while text is selected (Windows Terminal / VS Code
+  // convention); with nothing selected it stays the shell's SIGINT.
+  if (ev.ctrlKey && !ev.shiftKey && opts.hasSelection && isLetter(ev, 'c')) return 'copy'
+  return null
+}
+
+// The Wails runtime reads and writes the native clipboard on the Go side, so
+// it is tried first: WebKitGTK has no navigator.clipboard.readText at all and
+// WebView2 permission-gates it. navigator.clipboard stays as the fallback for
+// running the frontend in a plain browser.
+async function writeClipboard(text: string): Promise<boolean> {
+  try {
+    if (await ClipboardSetText(text)) return true
+  } catch {
+    // runtime unavailable — fall through
+  }
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function readClipboard(): Promise<string | null> {
+  try {
+    return await ClipboardGetText()
+  } catch {
+    // runtime unavailable — fall through
+  }
+  try {
+    return await navigator.clipboard.readText()
+  } catch {
+    return null
+  }
+}
+
+// Clearing the selection after a copy is what makes the next plain Ctrl+C a
+// real SIGINT instead of a second copy.
+export async function copySelection(term: Terminal): Promise<void> {
+  const text = term.getSelection()
+  if (!text) return
+  if (await writeClipboard(text)) {
+    term.clearSelection()
+  } else {
+    toast.error('Could not copy to the clipboard')
+  }
+}
+
+// term.paste() — not a raw write to the session — so the text gets the same
+// treatment as a native paste: newline normalisation and bracketed-paste
+// wrapping when the shell asked for it, then it flows out through onData.
+export async function pasteClipboard(term: Terminal): Promise<void> {
+  const text = await readClipboard()
+  if (text === null) {
+    toast.error('Could not read the clipboard')
+    return
+  }
+  if (text) term.paste(text)
+  term.focus()
+}
+
+export function installClipboardBindings(
+  term: Terminal,
+  opts: { readOnly?: boolean } = {},
+): void {
+  term.attachCustomKeyEventHandler((ev) => {
+    const action = clipboardActionFor(ev, { hasSelection: term.hasSelection(), isMac: IS_MAC })
+    if (!action || (action === 'paste' && opts.readOnly)) return true
+    // Returning false only stops xterm; the webview would still run its own
+    // binding for the chord (Ctrl+Shift+C opens the inspector in some builds).
+    ev.preventDefault()
+    if (ev.type === 'keydown') {
+      if (action === 'copy') void copySelection(term)
+      else void pasteClipboard(term)
+    }
+    return false
+  })
+}

--- a/frontend/src/features/nodes/NodeShellTab.tsx
+++ b/frontend/src/features/nodes/NodeShellTab.tsx
@@ -6,6 +6,7 @@ import { EventsOff, EventsOn } from '@/lib/wails/wailsjs/runtime/runtime'
 import { Button } from '@/components/ui/button'
 import { api } from '@/lib/api'
 import { xtermThemeFor } from '@/features/_shared/xtermTheme'
+import { installClipboardBindings } from '@/features/_shared/xtermClipboard'
 import { useUIStore } from '@/store/ui'
 
 type Props = {
@@ -41,6 +42,7 @@ export function NodeShellTab({ contextName, nodeName }: Props) {
     const fit = new FitAddon()
     term.loadAddon(fit)
     term.open(termHostRef.current)
+    installClipboardBindings(term)
     fit.fit()
     termRef.current = term
     fitRef.current = fit

--- a/frontend/src/features/nodes/NodeShellTab.tsx
+++ b/frontend/src/features/nodes/NodeShellTab.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { api } from '@/lib/api'
 import { xtermThemeFor } from '@/features/_shared/xtermTheme'
 import { installClipboardBindings } from '@/features/_shared/xtermClipboard'
+import { TerminalContextMenu } from '@/features/_shared/TerminalContextMenu'
 import { useUIStore } from '@/store/ui'
 
 type Props = {
@@ -174,7 +175,9 @@ export function NodeShellTab({ contextName, nodeName }: Props) {
           {error}
         </div>
       )}
-      <div ref={termHostRef} className="min-h-0 flex-1 bg-background px-2 py-1" />
+      <TerminalContextMenu terminal={() => termRef.current}>
+        <div ref={termHostRef} className="min-h-0 flex-1 bg-background px-2 py-1" />
+      </TerminalContextMenu>
     </div>
   )
 }

--- a/frontend/src/features/pods/PodExecTab.tsx
+++ b/frontend/src/features/pods/PodExecTab.tsx
@@ -11,6 +11,7 @@ import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { api, type PodDetail } from '@/lib/api'
 import { xtermThemeFor } from '@/features/_shared/xtermTheme'
+import { installClipboardBindings } from '@/features/_shared/xtermClipboard'
 import { InlinePicker } from '@/features/_shared/InlinePicker'
 import { TerminalAppPickerDialog } from '@/features/terminal/TerminalAppPickerDialog'
 import { useTerminalStore } from '@/store/terminals'
@@ -83,6 +84,7 @@ export function PodExecTab({ detail, contextName, active }: Props) {
     const fit = new FitAddon()
     term.loadAddon(fit)
     term.open(termHostRef.current)
+    installClipboardBindings(term)
     fit.fit()
     termRef.current = term
     fitRef.current = fit

--- a/frontend/src/features/pods/PodExecTab.tsx
+++ b/frontend/src/features/pods/PodExecTab.tsx
@@ -13,6 +13,7 @@ import { api, type PodDetail } from '@/lib/api'
 import { xtermThemeFor } from '@/features/_shared/xtermTheme'
 import { installClipboardBindings } from '@/features/_shared/xtermClipboard'
 import { InlinePicker } from '@/features/_shared/InlinePicker'
+import { TerminalContextMenu } from '@/features/_shared/TerminalContextMenu'
 import { TerminalAppPickerDialog } from '@/features/terminal/TerminalAppPickerDialog'
 import { useTerminalStore } from '@/store/terminals'
 import { useUIStore } from '@/store/ui'
@@ -440,7 +441,9 @@ export function PodExecTab({ detail, contextName, active }: Props) {
           {error}
         </div>
       )}
-      <div ref={termHostRef} className="min-h-0 flex-1 bg-background px-2 py-1" />
+      <TerminalContextMenu terminal={() => termRef.current}>
+        <div ref={termHostRef} className="min-h-0 flex-1 bg-background px-2 py-1" />
+      </TerminalContextMenu>
 
       <TerminalAppPickerDialog
         open={externalOpen}

--- a/frontend/src/features/pods/PodLogsTab.tsx
+++ b/frontend/src/features/pods/PodLogsTab.tsx
@@ -11,6 +11,7 @@ import { xtermThemeFor } from '@/features/_shared/xtermTheme'
 import { installClipboardBindings } from '@/features/_shared/xtermClipboard'
 import { highlightLogContent } from '@/features/_shared/logHighlight'
 import { InlinePicker } from '@/features/_shared/InlinePicker'
+import { TerminalContextMenu } from '@/features/_shared/TerminalContextMenu'
 import { useUIStore } from '@/store/ui'
 
 const TAIL_LINES = 200
@@ -383,7 +384,9 @@ export function PodLogsTab({ detail, contextName, initialContainer, active }: Pr
         </div>
       )}
       <div className="relative min-h-0 flex-1">
-        <div ref={termHostRef} className="absolute inset-0 bg-background px-2 py-1" />
+        <TerminalContextMenu terminal={() => termRef.current} readOnly>
+          <div ref={termHostRef} className="absolute inset-0 bg-background px-2 py-1" />
+        </TerminalContextMenu>
         {!atBottom && (
           <button
             type="button"

--- a/frontend/src/features/pods/PodLogsTab.tsx
+++ b/frontend/src/features/pods/PodLogsTab.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { EventsOff, EventsOn } from '@/lib/wails/wailsjs/runtime/runtime'
 import { api, type PodDetail } from '@/lib/api'
 import { xtermThemeFor } from '@/features/_shared/xtermTheme'
+import { installClipboardBindings } from '@/features/_shared/xtermClipboard'
 import { highlightLogContent } from '@/features/_shared/logHighlight'
 import { InlinePicker } from '@/features/_shared/InlinePicker'
 import { useUIStore } from '@/store/ui'
@@ -126,6 +127,7 @@ export function PodLogsTab({ detail, contextName, initialContainer, active }: Pr
     const fit = new FitAddon()
     term.loadAddon(fit)
     term.open(termHostRef.current)
+    installClipboardBindings(term, { readOnly: true })
     fit.fit()
     termRef.current = term
     fitRef.current = fit

--- a/frontend/src/features/terminal/TerminalTab.tsx
+++ b/frontend/src/features/terminal/TerminalTab.tsx
@@ -5,6 +5,7 @@ import '@xterm/xterm/css/xterm.css'
 import { EventsOff, EventsOn } from '@/lib/wails/wailsjs/runtime/runtime'
 import { api } from '@/lib/api'
 import { xtermThemeFor } from '@/features/_shared/xtermTheme'
+import { installClipboardBindings } from '@/features/_shared/xtermClipboard'
 import { useUIStore } from '@/store/ui'
 
 type Props = {
@@ -50,6 +51,7 @@ export function TerminalTab({ tabId, contextName, active }: Props) {
     const fit = new FitAddon()
     term.loadAddon(fit)
     term.open(hostRef.current)
+    installClipboardBindings(term)
     fit.fit()
     termRef.current = term
     fitRef.current = fit

--- a/frontend/src/features/terminal/TerminalTab.tsx
+++ b/frontend/src/features/terminal/TerminalTab.tsx
@@ -6,6 +6,7 @@ import { EventsOff, EventsOn } from '@/lib/wails/wailsjs/runtime/runtime'
 import { api } from '@/lib/api'
 import { xtermThemeFor } from '@/features/_shared/xtermTheme'
 import { installClipboardBindings } from '@/features/_shared/xtermClipboard'
+import { TerminalContextMenu } from '@/features/_shared/TerminalContextMenu'
 import { useUIStore } from '@/store/ui'
 
 type Props = {
@@ -186,7 +187,9 @@ export function TerminalTab({ tabId, contextName, active }: Props) {
           </button>
         </div>
       )}
-      <div ref={hostRef} className="min-h-0 flex-1 bg-background px-2 py-1" />
+      <TerminalContextMenu terminal={() => termRef.current}>
+        <div ref={hostRef} className="min-h-0 flex-1 bg-background px-2 py-1" />
+      </TerminalContextMenu>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Copy and paste never worked in Klustr's terminals on Linux and Windows — Exec, Node shell, the terminal drawer, and copying from the Logs viewers. Reported in discussion #90.

**Root cause.** On macOS the Wails Edit menu turns ⌘C / ⌘V into native clipboard commands and xterm.js leaves ⌘-chords alone, so it always worked there. Linux (WebKit2GTK) and Windows (WebView2) have no such menu; xterm.js maps Ctrl+C / Ctrl+V to the `^C` / `^V` control bytes and calls `preventDefault()`, so the webview never fires a `copy` / `paste` event and xterm's own clipboard handlers never run. Right-click was dead as well: release builds don't enable the webview's default context menu.

**Fix.**
- `xtermClipboard.ts` — `attachCustomKeyEventHandler` binds the terminal-convention chords on Linux/Windows: `Ctrl+Shift+C` / `Ctrl+Insert` copy, `Ctrl+Shift+V` / `Shift+Insert` paste, and a plain `Ctrl+C` copies while text is selected (SIGINT otherwise, matching Windows Terminal and VS Code). macOS is untouched — the matcher returns `null` there.
- Clipboard I/O goes through the Wails runtime (`ClipboardGetText` / `ClipboardSetText`) first: WebKitGTK has no `navigator.clipboard.readText` and WebView2 permission-gates it. Paste uses `term.paste()` so bracketed paste and newline normalisation survive.
- `TerminalContextMenu.tsx` — right-click Copy / Paste / Select all on every terminal surface (copy-only in the Logs viewers), focus handed back to xterm on close.
- Cheatsheet entries and guide docs.

## Verification

- `npm test` (188 passing, 7 new for the chord matcher), `npm run lint`, `npm run typecheck`, `npm run build`.
- Manual on Linux (`wails build -tags webkit2_41`, WebKitGTK 2.52): Exec, Node shell, drawer and Logs — chords, selection-aware Ctrl+C followed by SIGINT, right-click menu, multi-line paste into bash and vim; no regressions on Ctrl+D/L/R, arrows, Tab.
- macOS: keyboard path unchanged by construction; the right-click menu is new.
- Windows: same code path (Wails disables WebView2 browser accelerator keys and implements the clipboard runtime); confirmation from a Windows build requested in #90.

Refs #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
